### PR TITLE
fix(computed-previous): Don't return null for initial value, but retu…

### DIFF
--- a/docs/src/content/docs/utilities/Signals/computed-previous.md
+++ b/docs/src/content/docs/utilities/Signals/computed-previous.md
@@ -7,7 +7,7 @@ contributors: ['enea-jahollari']
 ---
 
 `computedPrevious` is a helper function that returns a `signal` that emits the previous value of the passed `signal`. It's useful when you want to keep track of the previous value of a signal.
-It will emit `null` as the previous value when the signal is first created.
+As the initial value it will emit the current value of the signal, and then it will emit the previous value every time the signal changes.
 
 ```ts
 import { computedPrevious } from 'ngxtension/computed-previous';
@@ -21,7 +21,7 @@ import { computedPrevious } from 'ngxtension/computed-previous';
 const a = signal(1);
 const b = computedPrevious(a);
 
-console.log(b()); // null
+console.log(b()); // 1
 
 a.set(2);
 console.log(b()); // 1
@@ -33,5 +33,5 @@ console.log(b()); // 2
 ## API
 
 ```ts
-computedPrevious<T>(signal: Signal<T>): Signal<T | null>
+computedPrevious<T>(signal: Signal<T>): Signal<T>
 ```

--- a/libs/ngxtension/computed-previous/src/computed-previous.spec.ts
+++ b/libs/ngxtension/computed-previous/src/computed-previous.spec.ts
@@ -19,7 +19,7 @@ describe(computedPrevious.name, () => {
 		const cmp = setup();
 
 		expect(cmp.value()).toEqual(0);
-		expect(cmp.previous()).toEqual(null);
+		expect(cmp.previous()).toEqual(0);
 
 		cmp.value.set(1);
 

--- a/libs/ngxtension/computed-previous/src/computed-previous.ts
+++ b/libs/ngxtension/computed-previous/src/computed-previous.ts
@@ -1,8 +1,8 @@
-import { computed, type Signal } from '@angular/core';
+import { computed, untracked, type Signal } from '@angular/core';
 
 /**
  * Returns a signal that emits the previous value of the given signal.
- * The first time the signal is emitted, the previous value will be `null`.
+ * The first time the signal is emitted, the previous value will be the same as the current value.
  *
  * @example
  * ```ts
@@ -16,28 +16,32 @@ import { computed, type Signal } from '@angular/core';
  *
  * Logs:
  * // Current value: 0
- * // Previous value: null
+ * // Previous value: 0
  *
  * value.set(1);
  *
  * Logs:
  * // Current value: 1
  * // Previous value: 0
+ *
+ * value.set(2);
+ *
+ * Logs:
+ * // Current value: 2
+ * // Previous value: 1
  *```
-
+ *
  * @param s Signal to compute previous value for
  * @returns Signal that emits previous value of `s`
  */
-export function computedPrevious<T>(s: Signal<T>): Signal<T | null> {
+export function computedPrevious<T>(s: Signal<T>): Signal<T> {
 	let current = null as T;
-	let previous = null as T;
+	let previous = untracked(() => s()); // initial value is the current value
 
 	return computed(() => {
-		const value = s();
-		if (value !== current) {
-			previous = current;
-			current = value;
-		}
-		return previous;
+		current = s();
+		const result = previous;
+		previous = current;
+		return result;
 	});
 }


### PR DESCRIPTION
…rn the current value of the source signal instead


Is this a breaking change? 🤔