### PR TITLE
feat(create-resource): Initial implementation of createResource

### DIFF
--- a/docs/src/content/docs/utilities/Signals/computed-previous.md
+++ b/docs/src/content/docs/utilities/Signals/computed-previous.md
@@ -7,7 +7,7 @@ contributors: ['enea-jahollari']
 ---
 
 `computedPrevious` is a helper function that returns a `signal` that emits the previous value of the passed `signal`. It's useful when you want to keep track of the previous value of a signal.
-It will emit `null` as the previous value when the signal is first created.
+As the initial value it will emit the current value of the signal, and then it will emit the previous value every time the signal changes.
 
 ```ts
 import { computedPrevious } from 'ngxtension/computed-previous';
@@ -21,7 +21,7 @@ import { computedPrevious } from 'ngxtension/computed-previous';
 const a = signal(1);
 const b = computedPrevious(a);
 
-console.log(b()); // null
+console.log(b()); // 1
 
 a.set(2);
 console.log(b()); // 1
@@ -33,5 +33,5 @@ console.log(b()); // 2
 ## API
 
 ```ts
-computedPrevious<T>(signal: Signal<T>): Signal<T | null>
+computedPrevious<T>(signal: Signal<T>): Signal<T>
 ```

--- a/libs/ngxtension/computed-previous/src/computed-previous.spec.ts
+++ b/libs/ngxtension/computed-previous/src/computed-previous.spec.ts
@@ -19,7 +19,7 @@ describe(computedPrevious.name, () => {
 		const cmp = setup();
 
 		expect(cmp.value()).toEqual(0);
-		expect(cmp.previous()).toEqual(null);
+		expect(cmp.previous()).toEqual(0);
 
 		cmp.value.set(1);
 

--- a/libs/ngxtension/computed-previous/src/computed-previous.ts
+++ b/libs/ngxtension/computed-previous/src/computed-previous.ts
@@ -1,8 +1,8 @@
-import { computed, type Signal } from '@angular/core';
+import { computed, untracked, type Signal } from '@angular/core';
 
 /**
  * Returns a signal that emits the previous value of the given signal.
- * The first time the signal is emitted, the previous value will be `null`.
+ * The first time the signal is emitted, the previous value will be the same as the current value.
  *
  * @example
  * ```ts
@@ -16,28 +16,32 @@ import { computed, type Signal } from '@angular/core';
  *
  * Logs:
  * // Current value: 0
- * // Previous value: null
+ * // Previous value: 0
  *
  * value.set(1);
  *
  * Logs:
  * // Current value: 1
  * // Previous value: 0
+ *
+ * value.set(2);
+ *
+ * Logs:
+ * // Current value: 2
+ * // Previous value: 1
  *```
-
+ *
  * @param s Signal to compute previous value for
  * @returns Signal that emits previous value of `s`
  */
-export function computedPrevious<T>(s: Signal<T>): Signal<T | null> {
+export function computedPrevious<T>(s: Signal<T>): Signal<T> {
 	let current = null as T;
-	let previous = null as T;
+	let previous = untracked(() => s()); // initial value is the current value
 
 	return computed(() => {
-		const value = s();
-		if (value !== current) {
-			previous = current;
-			current = value;
-		}
-		return previous;
+		current = s();
+		const result = previous;
+		previous = current;
+		return result;
 	});
 }

--- a/libs/ngxtension/create-resource/README.md
+++ b/libs/ngxtension/create-resource/README.md
@@ -1,0 +1,3 @@
+# ngxtension/create-resource
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/create-resource`.

--- a/libs/ngxtension/create-resource/ng-package.json
+++ b/libs/ngxtension/create-resource/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/create-resource/project.json
+++ b/libs/ngxtension/create-resource/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/create-resource",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/create-resource/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["create-resource"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/create-resource/src/create-resource.spec.ts
+++ b/libs/ngxtension/create-resource/src/create-resource.spec.ts
@@ -1,0 +1,370 @@
+import { signal } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { createResource } from './create-resource';
+
+const promise = <T>(value: T, time: number = 0): Promise<T> =>
+	new Promise((resolve) => setTimeout(() => resolve(value), time));
+
+describe(createResource.name, () => {
+	it('fetcher only', fakeAsync(() => {
+		TestBed.runInInjectionContext(() => {
+			const value = signal(1);
+
+			const res = createResource(() =>
+				promise(value(), 100).then((v) => {
+					logs.push(v);
+					return v;
+				}),
+			);
+
+			const logs: number[] = [];
+
+			expect(res.data()).toEqual(undefined); // initial value
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('unresolved');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(1);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1]);
+
+			value.set(2);
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(2);
+			expect(res.latest()).toEqual(2);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+		});
+	}));
+
+	it('fetcher + initial value', fakeAsync(() => {
+		TestBed.runInInjectionContext(() => {
+			const value = signal(1);
+
+			const res = createResource(
+				() =>
+					promise(value(), 100).then((v) => {
+						logs.push(v);
+						return v;
+					}),
+				{ initialValue: 0 },
+			);
+
+			const logs: number[] = [];
+
+			expect(res.data()).toEqual(0); // initial value
+			expect(res.latest()).toEqual(0);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(0);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(1);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1]);
+
+			value.set(2);
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(2);
+			expect(res.latest()).toEqual(2);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+		});
+	}));
+
+	it('source + fetcher', fakeAsync(() => {
+		TestBed.runInInjectionContext(() => {
+			const value = signal(1);
+			const fetcher = (id: number) =>
+				promise(id, 100).then((v) => {
+					logs.push(v);
+					return v;
+				});
+
+			const res = createResource<number>(
+				value,
+				// TODO: fix types
+				// @ts-ignore
+				fetcher,
+			);
+
+			const logs: number[] = [];
+
+			expect(res.data()).toEqual(undefined); // initial value
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('unresolved');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(1);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1]);
+
+			value.set(2);
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(2);
+			expect(res.latest()).toEqual(2);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+		});
+	}));
+
+	it('source + fetcher + initial value', fakeAsync(() => {
+		TestBed.runInInjectionContext(() => {
+			const value = signal(1);
+			const fetcher = (id: number) =>
+				promise(id, 100).then((v) => {
+					logs.push(v);
+					return v;
+				});
+
+			const res = createResource<number>(
+				value,
+				// TODO: fix types
+				// @ts-ignore
+				fetcher,
+				{ initialValue: 0 },
+			);
+
+			const logs: number[] = [];
+
+			expect(res.data()).toEqual(0); // initial value
+			expect(res.latest()).toEqual(0);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(0);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(1);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1]);
+
+			value.set(2);
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(2);
+			expect(res.latest()).toEqual(2);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+		});
+	}));
+
+	it('refresh', fakeAsync(() => {
+		TestBed.runInInjectionContext(() => {
+			const value = signal(1);
+
+			const res = createResource(() =>
+				promise(value(), 100).then((v) => {
+					logs.push(v);
+					return v;
+				}),
+			);
+
+			const logs: number[] = [];
+
+			expect(res.data()).toEqual(undefined); // initial value
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('unresolved');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(1);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1]);
+
+			res.refetch();
+			TestBed.flushEffects(); // depends on the effect to trigger the refetch
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('refreshing');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(1);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+		});
+	}));
+
+	it('mutate', fakeAsync(() => {
+		TestBed.runInInjectionContext(() => {
+			const value = signal(1);
+
+			const res = createResource(() =>
+				promise(value(), 100).then((v) => {
+					logs.push(v);
+					return v;
+				}),
+			);
+
+			const logs: number[] = [];
+
+			expect(res.data()).toEqual(undefined); // initial value
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('unresolved');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(undefined);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(1);
+			expect(res.latest()).toEqual(1);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1]);
+
+			res.mutate(2);
+
+			expect(res.data()).toEqual(2);
+			expect(res.latest()).toEqual(2);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1]);
+
+			// change the value to trigger the fetcher again
+			value.set(3);
+			TestBed.flushEffects();
+
+			expect(res.data()).toEqual(undefined);
+			expect(res.latest()).toEqual(2);
+			expect(res.status()).toEqual('pending');
+			expect(res.loading()).toEqual(true);
+			expect(res.error()).toEqual(undefined);
+
+			tick(100); // wait 100ms for promise to resolve
+
+			expect(res.data()).toEqual(3);
+			expect(res.latest()).toEqual(3);
+			expect(res.status()).toEqual('ready');
+			expect(res.loading()).toEqual(false);
+			expect(res.error()).toEqual(undefined);
+
+			expect(logs).toEqual([1, 3]);
+		});
+	}));
+});

--- a/libs/ngxtension/create-resource/src/create-resource.ts
+++ b/libs/ngxtension/create-resource/src/create-resource.ts
@@ -1,0 +1,285 @@
+import {
+	Injector,
+	computed,
+	effect,
+	isSignal,
+	signal,
+	untracked,
+	type Signal,
+} from '@angular/core';
+import { assertInjector } from 'ngxtension/assert-injector';
+import { computedPrevious } from 'ngxtension/computed-previous';
+
+interface CreateResourceOptions {
+	injector?: Injector;
+}
+
+export type CreateResourceSource<TValue> = Signal<TValue | undefined>;
+
+export type CreateResourceStatus =
+	| 'unresolved'
+	| 'pending'
+	| 'ready'
+	| 'refreshing'
+	| 'errored';
+
+interface Resource<TValue, TError = string> {
+	data: Signal<TValue>;
+	status: Signal<CreateResourceStatus>;
+	error: Signal<TError | undefined>;
+	loading: Signal<boolean>;
+	latest: Signal<TValue>;
+	refetch: () => void;
+	mutate: (value: TValue) => void;
+	destroy: () => void;
+}
+
+// TODO: FIX types as they don't play well
+// Add better naming for the types ex: sourceOrFetcher, fetcherOrOptions
+
+// fetcher with options
+export function createResource<TValue, TError = string>(
+	fetcher: () => Promise<TValue>,
+	options?: CreateResourceOptions & { initialValue?: undefined },
+): Resource<TValue | undefined, TError>;
+
+// fetcher with options + initial value
+export function createResource<TValue, TError = string>(
+	fetcher: () => Promise<TValue>,
+	options: CreateResourceOptions & { initialValue: TValue },
+): Resource<TValue, TError>;
+
+// source + fetcher + options
+export function createResource<TValue, TError = string>(
+	source: Signal<TValue | undefined | null>,
+	fetcher: (source: TValue | undefined) => Promise<TValue>,
+	options?: CreateResourceOptions & { initialValue?: TValue },
+): Resource<TValue | undefined, TError>;
+
+// source + fetcher + options + initial value
+export function createResource<TValue, TError = string>(
+	source: Signal<TValue | undefined>,
+	fetcher: (source: TValue | undefined) => Promise<TValue>,
+	options: CreateResourceOptions & { initialValue: TValue },
+): Resource<TValue, TError>;
+
+export function createResource<TValue, TError = string>(
+	source:
+		| Signal<TValue | undefined>
+		| ((source?: TValue | undefined) => Promise<TValue>),
+	fetcher: (
+		source: TValue | undefined,
+	) => Promise<TValue> | (CreateResourceOptions & { initialValue: TValue }),
+	options?: CreateResourceOptions & { initialValue?: undefined },
+): Resource<TValue, TError>;
+
+export function createResource<TValue, TError = string>(
+	source: Signal<TValue> | ((source: TValue) => Promise<TValue>),
+	fetcher: (
+		source: TValue,
+	) => Promise<TValue> | (CreateResourceOptions & { initialValue: TValue }),
+	options: CreateResourceOptions & { initialValue: TValue },
+): Resource<TValue, TError>;
+
+/**
+ *
+ * This function creates a resource that can be used to fetch data from an API or any other source.
+ * It returns an object with the following properties:
+ * - data: a signal that contains the data
+ * - status: a signal that contains the status of the resource
+ * - error: a signal that contains the error if the resource is in an errored state
+ * - loading: a signal that contains a boolean indicating if the resource is loading
+ * - latest: a function that returns the latest value of the resource
+ * - refetch: a function that refetches the resource
+ * - mutate: a function that updates the value of the resource
+ * - destroy: a function that destroys the resource
+ *
+ * @example
+ *
+ * getUser(id: string): Promise<User> {
+ *   return fetch(`/api/users/${id}`).then(res => res.json());
+ * }
+ *
+ * userId = injectQueryParam('userId');
+ *
+ * res = createResource(() => this.getUser(this.userId()));
+ * or
+ * res = createResource(this.userId, this.getUser);
+ *
+ * res.data() // returns undefined
+ * res.loading() // returns true
+ * res.error() // returns undefined
+ * res.latest() // returns undefined
+ *
+ * // After the promise resolves
+ *
+ * res.data() // returns User
+ * res.loading() // returns false
+ * res.error() // returns undefined
+ * res.latest() // returns User
+ *
+ * // After the promise rejects
+ *
+ * res.data() // returns undefined
+ * res.loading() // returns false
+ * res.error() // returns Error
+ * res.latest() // returns undefined
+ *
+ * // After calling refetch
+ *
+ * res.data() // returns undefined
+ * res.loading() // returns true
+ * res.error() // returns undefined
+ * res.latest() // returns User
+ *
+ * // After calling mutate
+ *
+ * res.data() // returns User
+ * res.loading() // returns false
+ * res.error() // returns undefined
+ * res.latest() // returns User
+ *
+ *
+ */
+export function createResource<TValue, TError = string>(...args: unknown[]) {
+	const { source, fetcher, options } = parseArgs<TValue>(args);
+
+	if (fetcher === undefined) {
+		throw new Error('fetcher is required');
+	}
+
+	const value = signal<TValue | undefined>(options.initialValue);
+	const error = signal<TError | undefined>(undefined);
+	const trigger = signal(0);
+	const state = signal<CreateResourceStatus>(
+		'initialValue' in options ? 'ready' : 'unresolved',
+	);
+
+	const latest = signal<TValue | undefined>(value());
+
+	const previousTrigger = computedPrevious(trigger);
+
+	return assertInjector(createResource, options.injector, () => {
+		const effectRef = effect(() => {
+			trigger(); // used to trigger the effect and for refetching
+
+			const promise = source ? fetcher(source()) : fetcher();
+
+			// we don't want to track anything else except the source and the fetcher
+			untracked(() => {
+				// TODO: do we want to cancel the current promise if it's still pending? it's easy with observables 😅
+				load(promise!);
+			});
+		});
+
+		function load(p: Promise<TValue> | undefined) {
+			if (p && isPromise(p)) {
+				if (state() === 'pending' || state() === 'refreshing') return;
+
+				// if the trigger has changed, we want to refetch and set the state to refreshing
+				if (trigger() !== previousTrigger()) {
+					state.set('refreshing');
+				} else {
+					state.set('pending');
+				}
+
+				latest.set(value()); // store the latest value before the promise resolves
+				value.set(undefined); // clear the value
+
+				p.then(
+					(v) => {
+						value.set(v);
+						latest.set(v);
+						state.set('ready');
+					},
+					(e) => {
+						error.set(e);
+						state.set('errored');
+					},
+				);
+			}
+		}
+
+		function refetch() {
+			trigger.update((v) => v + 1);
+		}
+
+		// function destroy() {
+
+		// }
+
+		return {
+			data: value.asReadonly(),
+			status: state.asReadonly(),
+			error: error.asReadonly(),
+			loading: computed(
+				() => state() === 'pending' || state() === 'refreshing',
+			),
+			latest: () => {
+				if (state() === 'errored') {
+					throw error();
+				}
+				return latest();
+			},
+			refetch,
+			mutate: (newValue: TValue) => {
+				value.set(newValue);
+				latest.set(newValue);
+			},
+			destroy: () => {
+				// TODO: we want to cancel the promise
+
+				// we want to destroy the effect
+				effectRef.destroy();
+			},
+		};
+	});
+}
+
+function parseArgs<TValue>(args: unknown[]): {
+	source: CreateResourceSource<TValue> | undefined;
+	fetcher: (source?: TValue | undefined | null) => Promise<TValue> | undefined;
+	options: any;
+} {
+	if (args.length === 1) {
+		return {
+			source: undefined,
+			fetcher: args[0] as () => any,
+			options: {} as CreateResourceOptions,
+		};
+	}
+	if (args.length === 2) {
+		if (isSignal(args[0])) {
+			return {
+				source: args[0] as CreateResourceSource<any>,
+				fetcher: args[1] as () => any,
+				options: {} as CreateResourceOptions,
+			};
+		} else {
+			return {
+				source: undefined,
+				fetcher: args[0] as () => any,
+				options: args[1] as CreateResourceOptions,
+			};
+		}
+	}
+	if (args.length === 3) {
+		if (isSignal(args[0])) {
+			return {
+				source: args[0] as CreateResourceSource<any>,
+				fetcher: args[1] as () => any,
+				options: args[2] as CreateResourceOptions,
+			};
+		}
+	}
+
+	return {
+		source: undefined,
+		fetcher: () => undefined,
+		options: {} as CreateResourceOptions,
+	};
+}
+
+function isPromise<T>(value: any): value is Promise<T> {
+	return value && typeof value.then === 'function';
+}

--- a/libs/ngxtension/create-resource/src/index.ts
+++ b/libs/ngxtension/create-resource/src/index.ts
@@ -1,0 +1,1 @@
+export * from './create-resource';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -55,6 +55,9 @@
 			"ngxtension/create-injection-token": [
 				"libs/ngxtension/create-injection-token/src/index.ts"
 			],
+			"ngxtension/create-resource": [
+				"libs/ngxtension/create-resource/src/index.ts"
+			],
 			"ngxtension/create-signal": [
 				"libs/ngxtension/create-signal/src/index.ts"
 			],


### PR DESCRIPTION
This PR implements `createResource` and supports `Promise`s only. 

Open for discussion. 

Highly inspired from https://docs.solidjs.com/reference/basic-reactivity/create-resource

Depends on: https://github.com/nartc/ngxtension-platform/pull/281 for `computedPrevious` change.

