### PR TITLE
fix: reintroduce computedAsync which reexports and shows a deprecatio…

### DIFF
--- a/libs/ngxtension/computed-async/README.md
+++ b/libs/ngxtension/computed-async/README.md
@@ -1,0 +1,3 @@
+# ngxtension/computed-async
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/computed-async`.

--- a/libs/ngxtension/computed-async/ng-package.json
+++ b/libs/ngxtension/computed-async/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/computed-async/project.json
+++ b/libs/ngxtension/computed-async/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/computed-async",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/computed-async/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["computed-async"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/computed-async/src/index.ts
+++ b/libs/ngxtension/computed-async/src/index.ts
@@ -1,0 +1,11 @@
+import { derivedAsync } from 'ngxtension/derived-async';
+
+/**
+ * This function is deprecated. Use `derivedAsync` instead.
+ * Run: `npx ng update ngxtension@latest` to migrate automatically.
+ *
+ * @deprecated Use `derivedAsync` instead. Will be removed in v3.
+ */
+const computedAsync = derivedAsync;
+
+export { computedAsync };

--- a/libs/ngxtension/computed-from/README.md
+++ b/libs/ngxtension/computed-from/README.md
@@ -1,0 +1,3 @@
+# ngxtension/computed-from
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/computed-from`.

--- a/libs/ngxtension/computed-from/ng-package.json
+++ b/libs/ngxtension/computed-from/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/computed-from/project.json
+++ b/libs/ngxtension/computed-from/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/computed-from",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/computed-from/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["computed-from"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/computed-from/src/index.ts
+++ b/libs/ngxtension/computed-from/src/index.ts
@@ -1,0 +1,11 @@
+import { derivedFrom } from 'ngxtension/derived-from';
+
+/**
+ * This function is deprecated. Use `derivedFrom` instead.
+ * Run: `npx ng update ngxtension@latest` to migrate automatically.
+ *
+ * @deprecated Use `derivedFrom` instead. Will be removed in v3.
+ */
+const computedFrom = derivedFrom;
+
+export { computedFrom };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,12 @@
 				"libs/ngxtension/click-outside/src/index.ts"
 			],
 			"ngxtension/computed": ["libs/ngxtension/computed/src/index.ts"],
+			"ngxtension/computed-async": [
+				"libs/ngxtension/computed-async/src/index.ts"
+			],
+			"ngxtension/computed-from": [
+				"libs/ngxtension/computed-from/src/index.ts"
+			],
 			"ngxtension/computed-previous": [
 				"libs/ngxtension/computed-previous/src/index.ts"
 			],


### PR DESCRIPTION
…n notice

We need to release this in a patch I guess. And then I will remove it using the Breaking Changes flag and we can release a major. 