### PR TITLE
fix: ng update wasn't working because of broken path

### DIFF
--- a/libs/plugin/migrations.json
+++ b/libs/plugin/migrations.json
@@ -20,7 +20,7 @@
 		"rename-computed": {
 			"version": "2.3.0",
 			"description": "Rename 'computedFrom' and 'computedAsync' to 'derivedFrom' and 'derivedAsync'",
-			"implementation": "./src/migrations/rename-computeds/rename-computeds/compat"
+			"implementation": "./src/migrations/rename-computeds/compat"
 		}
 	}
 }


### PR DESCRIPTION
This needs to be merged and released in a patch.