### PR TITLE
fix(create-injectable): allow returning proxies from factory function

### DIFF
--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -65,7 +65,9 @@ describe(createInjectable.name, () => {
 
 	it('should be able to return proxy from factory function', () => {
 		const MyInjectable = createInjectable(() => {
-			const test = () => {};
+			const test = () => {
+				void 0;
+			};
 
 			Object.defineProperty(test, 'name', {
 				value: 'josh',

--- a/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.spec.ts
@@ -62,4 +62,28 @@ describe(createInjectable.name, () => {
 				expect(service.someProp).toEqual(1);
 			});
 	});
+
+	it('should be able to return proxy from factory function', () => {
+		const MyInjectable = createInjectable(() => {
+			const test = () => {};
+
+			Object.defineProperty(test, 'name', {
+				value: 'josh',
+			});
+
+			return new Proxy(test, {
+				get(target, property, receiver) {
+					return Reflect.get(target, property, receiver);
+				},
+				apply(target, thisArg, argumentsList) {
+					return Reflect.apply(target, thisArg, argumentsList);
+				},
+			});
+		});
+
+		TestBed.runInInjectionContext(() => {
+			const service = inject(MyInjectable);
+			expect(service.name).toEqual('josh');
+		});
+	});
 });

--- a/libs/ngxtension/create-injectable/src/create-injectable.ts
+++ b/libs/ngxtension/create-injectable/src/create-injectable.ts
@@ -7,7 +7,18 @@ export function createInjectable<TFactory extends (...args: any[]) => object>(
 	@Injectable({ providedIn: providedIn === 'scoped' ? null : providedIn })
 	class _Injectable {
 		constructor() {
-			Object.assign(this, factory());
+			const result: any = factory();
+
+			for (const key of Reflect.ownKeys(result)) {
+				Object.defineProperty(this, key, {
+					get: () => result[key],
+					set: (value: any) => {
+						result[key] = value;
+					},
+					enumerable: true,
+					configurable: true,
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
If the factory function for `createInjectable` returns a proxy not all of the objects properties would be properly copied over with just `Object.assign`