### PR TITLE
feat(signal-slice): add "Updated" signal for action sources

### DIFF
--- a/docs/src/content/docs/utilities/Signals/signal-slice.md
+++ b/docs/src/content/docs/utilities/Signals/signal-slice.md
@@ -169,6 +169,38 @@ this subject as an `actionSource` allows you to still trigger it through
 can be accessed on the state object, even if you need to create an external
 subject.
 
+## Action Updates
+
+Each `actionSource` will have an equivalent `Updated` version signal automatically generated that will be incremented each time the `actionSource` emits or completes, e.g:
+
+```ts
+  state = signalSlice({
+    initialState: this.initialState,
+    actionSources: {
+      load: (_state, $: Observable<void>) => $.pipe(
+        switchMap(() => this.someService.load()),
+        map(data => ({ someProperty: data })
+      )
+    }
+  })
+
+  effect(() => {
+    // triggered when `load` emits/completes and on init
+    console.log(state.loadUpdated())
+  })
+```
+
+This signal will return the current version, starting at `0`. If you do not want your `effect` to be triggered on initialisation you can check for the `0` version value, e.g:
+
+```ts
+effect(() => {
+	if (state.loadUpdated()) {
+		// triggered ONLY when `load` emits/completes
+		// NOT on init
+	}
+});
+```
+
 ## Action Streams
 
 The source/stream for each action is also exposed on the state object. That means that you can access:
@@ -177,7 +209,7 @@ The source/stream for each action is also exposed on the state object. That mean
 this.state.add$;
 ```
 
-Which will allow you to react to the `add` action being called.
+Which will allow you to react to the `add` action being called via an observable.
 
 ## Selectors
 

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -176,6 +176,38 @@ describe(signalSlice.name, () => {
 			});
 		});
 
+		it('should create action updates', () => {
+			TestBed.runInInjectionContext(() => {
+				const state = signalSlice({
+					initialState,
+					actionSources: {
+						increaseAge: (state, $: Observable<number>) =>
+							$.pipe(map((amount) => ({ age: state().age + amount }))),
+					},
+				});
+
+				expect(state.increaseAgeUpdated).toBeDefined();
+			});
+		});
+
+		it('should increment updated signal every time source emits', () => {
+			TestBed.runInInjectionContext(() => {
+				const state = signalSlice({
+					initialState,
+					actionSources: {
+						increaseAge: (state, $: Observable<number>) =>
+							$.pipe(map((amount) => ({ age: state().age + amount }))),
+					},
+				});
+
+				expect(state.increaseAgeUpdated()).toEqual(0);
+				state.increaseAge(1);
+				expect(state.increaseAgeUpdated()).toEqual(1);
+				state.increaseAge(1);
+				expect(state.increaseAgeUpdated()).toEqual(2);
+			});
+		});
+
 		it('should resolve the updated state as a promise after reducer is invoked', (done) => {
 			TestBed.runInInjectionContext(() => {
 				const state = signalSlice({

--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -15,7 +15,7 @@ describe(signalSlice.name, () => {
 	};
 
 	describe('initialState', () => {
-		let state: SignalSlice<typeof initialState, any, any, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -47,7 +47,7 @@ describe(signalSlice.name, () => {
 		const testSource$ = new Subject<Partial<typeof initialState>>();
 		const testSource2$ = new Subject<Partial<typeof initialState>>();
 
-		let state: SignalSlice<typeof initialState, any, any, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -117,7 +117,7 @@ describe(signalSlice.name, () => {
 			}),
 		);
 
-		let state: SignalSlice<typeof initialState, any, any, any, any>;
+		let state: SignalSlice<typeof initialState, any, any, any>;
 
 		beforeEach(() => {
 			TestBed.runInInjectionContext(() => {
@@ -361,166 +361,19 @@ describe(signalSlice.name, () => {
 					actionSources: {
 						someActionSource: (state, $: Observable<void>) =>
 							$.pipe(map(() => ({ age: state().age }))),
-						someOtherActionSource: (state, $: Observable<void>) =>
-							$.pipe(
-								map(() => {
-									testFn();
-									return {};
-								}),
-							),
 					},
-					actionEffects: (state) => ({
-						someActionSource: () => {
-							state.age();
-							state.someSelector();
-							state.someOtherActionSource();
-						},
-					}),
 					effects: (state) => ({
 						someEffect: () => {
 							state.age();
 							state.someSelector();
-							state.someActionSource();
-						},
-					}),
-				});
-
-				state.someActionSource();
-
-				expect(testFn).toHaveBeenCalled();
-			});
-		});
-	});
-
-	describe('actionEffects', () => {
-		it('should create effects for named actionEffects', (done) => {
-			TestBed.runInInjectionContext(() => {
-				const state = signalSlice({
-					initialState,
-					actionSources: {
-						test: (_state, $: Observable<void>) => $.pipe(map(() => ({}))),
-						load: (_state, $: Observable<void>) =>
-							$.pipe(
-								switchMap(() => of(35)),
-								map((age) => ({ age })),
-							),
-					},
-					actionEffects: (state) => ({
-						load: () => {
-							expect(state().age).toEqual(35);
-							done();
-						},
-					}),
-				});
-
-				state.load();
-				TestBed.flushEffects();
-			});
-		});
-
-		it('should not run until source emits', () => {
-			TestBed.runInInjectionContext(() => {
-				const testFn = jest.fn();
-				const block$ = new Subject<void>();
-
-				const state = signalSlice({
-					initialState,
-					actionSources: {
-						load: (_state, $: Observable<void>) =>
-							$.pipe(
-								switchMap(() => block$),
-								map(() => ({})),
-							),
-					},
-					actionEffects: () => ({
-						load: () => {
 							testFn();
 						},
 					}),
 				});
 
-				state.load();
-				expect(testFn).not.toHaveBeenCalled();
-				block$.next();
+				state.someActionSource();
+				TestBed.flushEffects();
 				expect(testFn).toHaveBeenCalled();
-			});
-		});
-
-		it('should supply appropriate values on action', () => {
-			TestBed.runInInjectionContext(() => {
-				const testFn = jest.fn();
-				const testPayload = 'a';
-				const age = 20;
-
-				const state = signalSlice({
-					initialState,
-					actionSources: {
-						test: (state, $: Observable<string>) =>
-							$.pipe(
-								map(() => ({
-									age,
-								})),
-							),
-					},
-					actionEffects: () => ({
-						test: (action) => {
-							testFn({
-								name: action.name,
-								payload: action.payload,
-								value: action.value,
-								err: action.err,
-							});
-						},
-					}),
-				});
-
-				state.test(testPayload);
-
-				expect(testFn).toHaveBeenCalledWith({
-					name: 'test',
-					payload: testPayload,
-					value: { age },
-					err: undefined,
-				});
-			});
-		});
-
-		it('should supply appropriate values to action on error', () => {
-			TestBed.runInInjectionContext(() => {
-				const testFn = jest.fn();
-				const testPayload = 'a';
-				const error = new Error('oops');
-
-				const state = signalSlice({
-					initialState,
-					actionSources: {
-						test: (state, $: Observable<string>) =>
-							$.pipe(
-								map(() => {
-									throw error;
-								}),
-							),
-					},
-					actionEffects: () => ({
-						test: (action) => {
-							testFn({
-								name: action.name,
-								payload: action.payload,
-								value: action.value,
-								err: action.err,
-							});
-						},
-					}),
-				});
-
-				state.test(testPayload);
-
-				expect(testFn).toHaveBeenCalledWith({
-					name: 'test',
-					payload: testPayload,
-					value: undefined,
-					err: error,
-				});
 			});
 		});
 	});

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -46,29 +46,6 @@ type Effects<TEffects extends NamedEffects> = {
 	[K in keyof TEffects]: EffectRef;
 };
 
-type InferPayload<T> =
-	T extends ActionSourceFn<any, infer TPayload> ? TPayload : never;
-
-type ActionSourcePayloadType<TActionSource> = InferPayload<TActionSource>;
-
-type ActionSourceReturnType<TActionSource> = TActionSource extends (
-	state: any,
-	value: any,
-) => Observable<infer TValue>
-	? TValue
-	: never;
-
-type NamedActionEffects<TActionSources> = Partial<{
-	[K in keyof TActionSources]: (action: {
-		name: K;
-		payload: ActionSourcePayloadType<TActionSources[K]>;
-		value: ActionSourceReturnType<TActionSources[K]>;
-		err: any;
-	}) => void;
-}>;
-
-type ActionEffects<TActionSources> = NamedActionEffects<TActionSources>;
-
 type Action<TSignalValue, TValue> = TValue extends [void]
 	? () => Promise<TSignalValue>
 	: [unknown] extends TValue
@@ -122,12 +99,10 @@ export type SignalSlice<
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects,
-	TActionEffects extends NamedActionEffects<TActionSources>,
 > = Signal<TSignalValue> &
 	Selectors<TSignalValue> &
 	ExtraSelectors<TSelectors> &
 	Effects<TEffects> &
-	ActionEffects<TActionEffects> &
 	ActionMethods<TSignalValue, TActionSources> &
 	ActionStreams<TSignalValue, TActionSources>;
 
@@ -147,7 +122,6 @@ export function signalSlice<
 	TActionSources extends NamedActionSources<TSignalValue>,
 	TSelectors extends NamedSelectors,
 	TEffects extends NamedEffects,
-	TActionEffects extends NamedActionEffects<TActionSources>,
 >(config: {
 	initialState: TSignalValue;
 	sources?: SourceConfig<TSignalValue>;
@@ -157,16 +131,7 @@ export function signalSlice<
 	effects?: (
 		state: EffectsState<TSignalValue, TActionSources, TSelectors>,
 	) => TEffects;
-	actionEffects?: (
-		state: EffectsState<TSignalValue, TActionSources, TSelectors>,
-	) => TActionEffects;
-}): SignalSlice<
-	TSignalValue,
-	TActionSources,
-	TSelectors,
-	TEffects,
-	TActionEffects
-> {
+}): SignalSlice<TSignalValue, TActionSources, TSelectors, TEffects> {
 	const destroyRef = inject(DestroyRef);
 	const injector = inject(Injector);
 
@@ -183,10 +148,6 @@ export function signalSlice<
 			(typeof config)['effects'],
 			undefined
 		>,
-		actionEffects = (() => ({})) as unknown as Exclude<
-			(typeof config)['actionEffects'],
-			undefined
-		>,
 	} = config;
 
 	const state = signal(initialState);
@@ -200,8 +161,7 @@ export function signalSlice<
 		TSignalValue,
 		TActionSources,
 		TSelectors,
-		TEffects,
-		TActionEffects
+		TEffects
 	>;
 
 	connectSources(state, sources);
@@ -209,9 +169,6 @@ export function signalSlice<
 	for (const [key, actionSource] of Object.entries(
 		actionSources as TActionSources,
 	)) {
-		const effectTrigger = new Subject<any>();
-		subs.push(effectTrigger);
-
 		if (isObservable(actionSource)) {
 			addReducerProperties(
 				readonlyState,
@@ -220,7 +177,6 @@ export function signalSlice<
 				destroyRef,
 				actionSource,
 				subs,
-				effectTrigger,
 			);
 		} else {
 			const subject = new Subject();
@@ -234,19 +190,9 @@ export function signalSlice<
 				destroyRef,
 				subject,
 				subs,
-				effectTrigger,
 				sharedObservable,
 			);
 		}
-
-		const actionEffectFns = actionEffects(slice);
-
-		effectTrigger.subscribe((action) => {
-			const effectFn = actionEffectFns[action.name];
-			if (effectFn) {
-				effectFn(action);
-			}
-		});
 	}
 
 	for (const key in initialState) {
@@ -262,6 +208,9 @@ export function signalSlice<
 	}
 
 	for (const [key, namedEffect] of Object.entries(effects(slice))) {
+		console.warn(
+			"The 'effects' configuration in signalSlice is deprecated. Please use standard signal effects outside of signalSlice instead.",
+		);
 		Object.defineProperty(slice, key, {
 			value: effect((onCleanup) => {
 				const maybeCleanup = namedEffect();
@@ -317,7 +266,6 @@ function addReducerProperties(
 	destroyRef: DestroyRef,
 	subject: Subject<unknown>,
 	subs: Subject<unknown>[],
-	effectTrigger: Subject<any>,
 	observableFromActionSource?: Observable<any>,
 ) {
 	Object.defineProperties(readonlyState, {
@@ -327,21 +275,9 @@ function addReducerProperties(
 					return new Promise((res, rej) => {
 						nextValue.pipe(takeUntilDestroyed(destroyRef)).subscribe({
 							next: (value) => {
-								effectTrigger.next({
-									name: key,
-									payload: nextValue,
-									value,
-									err: undefined,
-								});
 								subject.next(value);
 							},
 							error: (err) => {
-								effectTrigger.next({
-									name: key,
-									payload: nextValue,
-									value: undefined,
-									err,
-								});
 								subject.error(err);
 								rej(err);
 							},
@@ -356,24 +292,7 @@ function addReducerProperties(
 				if (observableFromActionSource) {
 					observableFromActionSource
 						.pipe(takeUntilDestroyed(destroyRef))
-						.subscribe({
-							next: (value) => {
-								effectTrigger.next({
-									name: key,
-									payload: nextValue,
-									value,
-									err: undefined,
-								});
-							},
-							error: (err) => {
-								effectTrigger.next({
-									name: key,
-									payload: nextValue,
-									value: undefined,
-									err,
-								});
-							},
-						});
+						.subscribe();
 				}
 
 				return new Promise((res) => {

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -89,6 +89,13 @@ type ActionStreams<
 			: never;
 };
 
+type ActionUpdates<
+	TSignalValue,
+	TActionSources extends NamedActionSources<TSignalValue>,
+> = {
+	[K in keyof TActionSources & string as `${K}Updated`]: Signal<number>;
+};
+
 export type Source<TSignalValue> = Observable<PartialOrValue<TSignalValue>>;
 type SourceConfig<TSignalValue> = Array<
 	Source<TSignalValue> | ((state: Signal<TSignalValue>) => Source<TSignalValue>)
@@ -104,7 +111,8 @@ export type SignalSlice<
 	ExtraSelectors<TSelectors> &
 	Effects<TEffects> &
 	ActionMethods<TSignalValue, TActionSources> &
-	ActionStreams<TSignalValue, TActionSources>;
+	ActionStreams<TSignalValue, TActionSources> &
+	ActionUpdates<TSignalValue, TActionSources>;
 
 type SelectorsState<TSignalValue extends NoOptionalProperties<TSignalValue>> =
 	Signal<TSignalValue> & Selectors<TSignalValue>;
@@ -268,6 +276,7 @@ function addReducerProperties(
 	subs: Subject<unknown>[],
 	observableFromActionSource?: Observable<any>,
 ) {
+	const version = signal(0);
 	Object.defineProperties(readonlyState, {
 		[key]: {
 			value: (nextValue: unknown) => {
@@ -275,6 +284,7 @@ function addReducerProperties(
 					return new Promise((res, rej) => {
 						nextValue.pipe(takeUntilDestroyed(destroyRef)).subscribe({
 							next: (value) => {
+								version.update((v) => v + 1);
 								subject.next(value);
 							},
 							error: (err) => {
@@ -282,6 +292,7 @@ function addReducerProperties(
 								rej(err);
 							},
 							complete: () => {
+								version.update((v) => v + 1);
 								subject.complete();
 								res(readonlyState());
 							},
@@ -299,12 +310,16 @@ function addReducerProperties(
 					state$.pipe(take(1)).subscribe((val) => {
 						res(val);
 					});
+					version.update((v) => v + 1);
 					subject.next(nextValue);
 				});
 			},
 		},
 		[`${key}$`]: {
 			value: subject.asObservable(),
+		},
+		[`${key}Updated`]: {
+			value: version.asReadonly(),
 		},
 	});
 	subs.push(subject);


### PR DESCRIPTION
NOTE: This depends on https://github.com/ngxtension/ngxtension-platform/pull/361 being merged, this is branched off of that feature

This is a replacement for the removal of the `actionEffect` API, instead it allows triggering side effects as a result of an `actionSource` emitting via a notifier/version signal (same general concept we used for `createNotifier`).

It adds a `<actionSourceName>Updated` signal for each action source e.g:

```ts
  state = signalSlice({
    initialState: this.initialState,
    actionSources: {
      load: (_state, $: Observable<void>) => $.pipe(
        switchMap(() => this.someService.load()),
        map(data => ({ someProperty: data })
      )
    }
  })

  effect(() => {
    // triggered when `load` emits/completes and on init
    console.log(state.loadUpdated())
  })

  effect(() => {
	if (state.loadUpdated()) {
	  // triggered ONLY when `load` emits/completes
	  // NOT on init
	}
  });
```

This is a much simpler API and avoids the typing issues (described in: https://github.com/ngxtension/ngxtension-platform/pull/361)