### PR TITLE
fix(plugin): remove additional semicolumns

### DIFF
--- a/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
@@ -48,17 +48,6 @@ export class MyCmp {
     _outputFromSubject = outputFromObservable(this.outputFromSubject, { alias: 'outputFromSubject' });
     /** TODO(migration): you may want to convert this to a normal output */
     _outputFromBehaviorSubject = outputFromObservable(this.outputFromBehaviorSubject, { alias: 'outputFromBehaviorSubject' });
-;
-;
-;
-;
-;
-;
-;
-;
-;
-;
-;
 }
 "
 `;
@@ -73,8 +62,6 @@ import { Component, output } from '@angular/core';
 export class MyCmp {
   outputWithoutType = output();
   normalOutput = output<string>();
-;
-;
 }
 "
 `;

--- a/libs/plugin/src/generators/convert-outputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.spec.ts
@@ -41,12 +41,12 @@ export class MyCmp {
   @Output() outputWithoutType = new EventEmitter();
 
   @Output() private outputWithPrivateScope = new EventEmitter();
-  @Output() protected outputWithProtectedScope = new EventEmitter();
+  @Output() protected outputWithProtectedScope = new EventEmitter()
   @Output() public outputWithPublicScope = new EventEmitter();
 
   @Output() normalOutput = new EventEmitter<string>();
 
-  @Output() someOutput: EventEmitter<DataInterface> = new EventEmitter();
+  @Output() someOutput: EventEmitter<DataInterface> = new EventEmitter()
 
   @Output() normalOutput2: EventEmitter<string> = new EventEmitter<string>();
 

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -77,7 +77,7 @@ function getOutputInitializer(
 					writer.write(`outputFromObservable`);
 					writer.write(`(this.${propertyName}`);
 					writer.write(`, { alias: ${alias ?? `'${propertyName}'`} }`);
-					writer.write(`);`);
+					writer.write(`)`);
 				},
 				outputName: `_${propertyName}`,
 				removeOnlyDecorator: true,
@@ -89,7 +89,7 @@ function getOutputInitializer(
 					writer.write(`outputFromObservable`);
 					writer.write(`(${initializer}`);
 					writer.write(`${alias ? `, { alias: ${alias} }` : ''}`);
-					writer.write(`);`);
+					writer.write(`)`);
 				},
 				needsOutputFromObservableImport: true,
 			};
@@ -117,7 +117,7 @@ function getOutputInitializer(
 				writer.write(`output`);
 				writer.write(`${type ? `<${type}>` : ''}(`);
 				writer.write(`${alias ? `, { alias: ${alias} }` : ''}`);
-				writer.write(`);`);
+				writer.write(`)`);
 			},
 			needsOutputFromObservableImport: false,
 		};

--- a/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-signal-inputs/__snapshots__/generator.spec.ts.snap
@@ -104,18 +104,6 @@ export class MyCmp {
       let test = this.requiredWithAliasAndTransform() + this.requiredWithAlias();
     }
   }
-
-;
-;
-;
-;
-;
-;
-;
-;
-;
-;
-;
 }
 "
 `;
@@ -166,9 +154,19 @@ export class RequestInfoComponent implements OnInit {
   search(): void {
     this.submitter$.next();
   }
-
-;
 }"
+`;
+
+exports[`convertSignalInputsGenerator should convert properly for issue #290 1`] = `
+"
+import { Component, input } from '@angular/core';
+
+@Component({})
+export class MyCmp {
+  inputWithoutType = input();
+  noColon = true
+}
+"
 `;
 
 exports[`convertSignalInputsGenerator should convert properly for issue #368Five 1`] = `
@@ -188,8 +186,6 @@ import { Component, input } from '@angular/core';
 export class InputComponent {
     height = input('100px');
     width = input('100px');
-;
-;
 }
   "
 `;
@@ -200,7 +196,6 @@ exports[`convertSignalInputsGenerator should convert properly for issue #368Four
 @Component({})
 export class InputComponent {
     desc = input<string | undefined>(undefined);
-;
 }
   "
 `;
@@ -222,8 +217,6 @@ exports[`convertSignalInputsGenerator should convert properly for issue #368One 
     export class InputComponent {
         label = input<string>();
         iconRight = input<string>();
-;
-;
     }
   "
 `;
@@ -249,8 +242,6 @@ import { Component, input } from '@angular/core';
 export class InputComponent {
     iconClass = input<string>('');
     icon = input<string>('');
-;
-;
 }
   "
 `;
@@ -270,7 +261,6 @@ import { FormsModule } from '@angular/forms';
 })
 export class InputComponent {
     search = input.required<string>();
-;
 }
   "
 `;
@@ -303,9 +293,6 @@ exports[`convertSignalInputsGenerator should convert properly for issue #368Two 
         sort = input<string>();
         ascText = input<string>();
         descText = input<string>();
-;
-;
-;
     }
   "
 `;
@@ -356,18 +343,6 @@ export class MyCmp {
       let test = this.requiredWithAliasAndTransform() + this.requiredWithAlias();
     }
   }
-
-;
-;
-;
-;
-;
-;
-;
-;
-;
-;
-;
 }
 "
 `;
@@ -444,7 +419,6 @@ import { Component, input } from '@angular/core';
 @Component({})
 export class MyCmp {
   hello = input<string>();
-;
 }
 "
 `;

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.spec.ts
@@ -409,12 +409,11 @@ describe('convertSignalInputsGenerator', () => {
 		expect(updated).toMatchSnapshot();
 	});
 
-	it('should fail for issue #290', async () => {
+	it('should convert properly for issue #290', async () => {
 		const readContent = setup('issue290');
-		await expect(async () => {
-			await convertSignalInputsGenerator(tree, options);
-			readContent();
-		}).rejects.toThrow();
+		await convertSignalInputsGenerator(tree, options);
+		const [updated] = readContent();
+		expect(updated).toMatchSnapshot();
 	});
 
 	it('should convert properly for issue #368One', async () => {

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -152,16 +152,15 @@ function getSignalInputInitializer(
 
 			writeTypeNodeAndInitializer(writer, required, transformType, true);
 			if (required) {
-				writer.write(optionsAsText ? `${optionsAsText});` : ');');
+				writer.write(optionsAsText ? `${optionsAsText})` : ')');
 			} else {
-				writer.write(optionsAsText ? `, ${optionsAsText});` : ');');
+				writer.write(optionsAsText ? `, ${optionsAsText})` : ')');
 			}
 		} else if (Node.isStringLiteral(decoratorArg)) {
 			writeTypeNodeAndInitializer(writer, false, '', true);
-			writer.write(`, { alias: ${decoratorArg.getText()} });`);
+			writer.write(`, { alias: ${decoratorArg.getText()} })`);
 		} else {
 			writeTypeNodeAndInitializer(writer, false, '', false);
-			writer.write(');');
 		}
 	};
 }


### PR DESCRIPTION
Remove additional semicolumns created by the input generator.
I might be missing something because it seems like this is desired (#290), but I cannot think of/create an invalid example.


If accepted, I'll also update the output generator as this has the same issue.

Also sorry for not creating an issue first 😅 - I can still do this.