### PR TITLE
fix(migrations): Update Migration Scripts for Angular 18 Compatibility

### DIFF
--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -153,7 +153,7 @@ export async function convertOutputsGenerator(
 			return Number(part);
 		});
 
-	if (major < 17 || (major >= 17 && minor < 3)) {
+	if ([major, minor] < [17, 3]) {
 		logger.error(`[ngxtension] output() is only available in v17.3 and later`);
 		return exit(1);
 	}

--- a/libs/plugin/src/generators/convert-queries/generator.ts
+++ b/libs/plugin/src/generators/convert-queries/generator.ts
@@ -164,7 +164,7 @@ export async function convertQueriesGenerator(
 			return Number(part);
 		});
 
-	if (major < 17 || (major >= 17 && minor < 3)) {
+	if ([major, minor] < [17, 3]) {
 		logger.error(`[ngxtension] output() is only available in v17.3 and later`);
 		return exit(1);
 	}

--- a/libs/plugin/src/generators/convert-queries/generator.ts
+++ b/libs/plugin/src/generators/convert-queries/generator.ts
@@ -165,7 +165,7 @@ export async function convertQueriesGenerator(
 		});
 
 	if ([major, minor] < [17, 3]) {
-		logger.error(`[ngxtension] output() is only available in v17.3 and later`);
+		logger.error(`[ngxtension] queries is only available in v17.3 and later`);
 		return exit(1);
 	}
 

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -193,7 +193,9 @@ export async function convertSignalInputsGenerator(
 		});
 
 	if ([major, minor] < [17, 1]) {
-		logger.error(`[ngxtension] signals is only available in v17.1 and later`);
+		logger.error(
+			`[ngxtension] Signal Input is only available in v17.1 and later`,
+		);
 		return exit(1);
 	}
 

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -192,10 +192,8 @@ export async function convertSignalInputsGenerator(
 			return Number(part);
 		});
 
-	if (major < 17 || (major >= 17 && minor < 1)) {
-		logger.error(
-			`[ngxtension] Signal Input is only available in v17.1 and later`,
-		);
+	if ([major, minor] < [17, 1]) {
+		logger.error(`[ngxtension] output() is only available in v17.1 and later`);
 		return exit(1);
 	}
 

--- a/libs/plugin/src/generators/convert-signal-inputs/generator.ts
+++ b/libs/plugin/src/generators/convert-signal-inputs/generator.ts
@@ -193,7 +193,7 @@ export async function convertSignalInputsGenerator(
 		});
 
 	if ([major, minor] < [17, 1]) {
-		logger.error(`[ngxtension] output() is only available in v17.1 and later`);
+		logger.error(`[ngxtension] signals is only available in v17.1 and later`);
 		return exit(1);
 	}
 


### PR DESCRIPTION
Issue encountered when attempting to execute migration scripts in the project after updating to Angular version 18. The migration scripts rely on the output() function, which is only available in Angular versions 17.3 and later. As a result, attempting to run these scripts on Angular 18 results in the following error:

`[ngxtension] output() is only available in v17.3 and later
`
