### PR TITLE
docs: add `explicitEffect` to the homepage

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -35,6 +35,7 @@ import { Card, CardGrid, Steps } from '@astrojs/starlight/components';
       - [<strong>createSignal/createComputed</strong> - vue style signals](/utilities/signals/create-signal/)
       - [<strong>computedPrevious</strong> - track previously emitted values](/utilities/signals/computed-previous/)
       - [<strong>computed/extendedComputed</strong> - enhanced computed with previously derived value](/utilities/signals/computed/)
+      - [<strong>explicitEffect</strong> - effect with explicit dependencies](/utilities/signals/explicit-effect/)
     </div>
   </Card>
   <Card title="Injector utilities" icon="star" >


### PR DESCRIPTION
We waited for the function to be released to add it to the homepage