### PR TITLE
Fix 404 on Gesture/intro and `mergeFrom` documentation

### DIFF
--- a/docs/src/content/docs/es/utilities/Gesture/intro.md
+++ b/docs/src/content/docs/es/utilities/Gesture/intro.md
@@ -19,7 +19,7 @@ sidebar:
 
 ### Comparación al Angular CDK
 
-[Angular CDK](https://cdk.angular.io) ofrece características como [Drag and Drop](https://material.angular.io/cdk/drag-drop/overview) y [Scrolling](https://material.angular.io/cdk/scrolling/overview),
+[Angular CDK](https://material.angular.io/cdk/categories) ofrece características como [Drag and Drop](https://material.angular.io/cdk/drag-drop/overview) y [Scrolling](https://material.angular.io/cdk/scrolling/overview),
 mientras que `ngxtension/gestures` se especializa en capturar gestos exclusivamente en elementos. En esencia, `ngxtension/gestures` opera desde una perspectiva más granular y de bajo nivel en comparación con Angular CDK.
 Su control detallado sobre los datos de los gestos te permite crear una amplia gama de interacciones y facilita la integración perfecta con bibliotecas de animación como [GSAP](https://greensock.com/gsap/).
 

--- a/docs/src/content/docs/utilities/Gesture/intro.md
+++ b/docs/src/content/docs/utilities/Gesture/intro.md
@@ -19,7 +19,7 @@ sidebar:
 
 ### Comparison to Angular CDK
 
-[Angular CDK](https://cdk.angular.io) offers features like [Drag & Drop](https://material.angular.io/cdk/drag-drop/overview) and [Scrolling](https://material.angular.io/cdk/scrolling/overview),
+[Angular CDK](https://material.angular.io/cdk/categories) offers features like [Drag & Drop](https://material.angular.io/cdk/drag-drop/overview) and [Scrolling](https://material.angular.io/cdk/scrolling/overview),
 while `ngxtension/gestures` specializes in capturing gestures on elements exclusively. In essence, `ngxtension/gestures` operates at a more granular, low-level perspective compared to Angular CDK.
 Its fine-grained control over Gesture data empowers you to craft a broader range of interactions and facilitates seamless integration with animation libraries such as [GSAP](https://greensock.com/gsap/).
 

--- a/docs/src/content/docs/utilities/Signals/merge-from.md
+++ b/docs/src/content/docs/utilities/Signals/merge-from.md
@@ -11,7 +11,7 @@ It also gives us the possibility to change the emitted value before emitting it 
 
 It is similar to `merge()`, but it also takes `Signals` into consideration.
 
-From `ngxtension` perspective, `mergeFrom` is similar to [`derivedFrom`](./derived-from.md), but it doesn't emit the combined value, but the latest emitted value by using the `merge` operator instead of `combineLatest`.
+From `ngxtension` perspective, `mergeFrom` is similar to [`derivedFrom`](/utilities/signals/derived-from), but it doesn't emit the combined value, but the latest emitted value by using the `merge` operator instead of `combineLatest`.
 
 ```ts
 import { mergeFrom } from 'ngxtension/merge-from';


### PR DESCRIPTION
This PR addresses:
- The `mergeFrom` used a relative link that didn't work, so I made it absolute to the utilities like other links.
- The Gesture intro page linked to the Angular CDK on a now dead page, so I pointed it at the CDK in the Material docs.

## Question about one other oddity that could be addressed in this PR
The `resize` pages in both ES/EN say
- "injectResize retorna un Observable<ResizeResult> (see [ResizeResult TBD](http://127.0.0.1:4321/es/utilities/directives/resize/))"

I assume this is a dead end placeholder?