### PR TITLE
fix(inject-migration): ng CLI option name problem

### DIFF
--- a/libs/plugin/src/generators/convert-di-to-inject/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-di-to-inject/generator.spec.ts
@@ -318,7 +318,7 @@ describe('convertDiToInjectGenerator', () => {
 		);
 		await convertDiToInjectGenerator(tree, {
 			...options,
-			useESPrivateFieldNotation: true,
+			useEsprivateFieldNotation: true,
 		});
 		const [updated] = readContent();
 		expect(updated).toMatchSnapshot();
@@ -339,7 +339,7 @@ describe('convertDiToInjectGenerator', () => {
 		await convertDiToInjectGenerator(tree, {
 			...options,
 			includeReadonlyByDefault: true,
-			useESPrivateFieldNotation: true,
+			useEsprivateFieldNotation: true,
 		});
 		const [updated] = readContent();
 		expect(updated).toMatchSnapshot();

--- a/libs/plugin/src/generators/convert-di-to-inject/generator.ts
+++ b/libs/plugin/src/generators/convert-di-to-inject/generator.ts
@@ -225,7 +225,7 @@ export async function convertDiToInjectGenerator(
 					} else {
 						const hasPrivateScope = scope === Scope.Private;
 						const propertyName =
-							hasPrivateScope && options.useESPrivateFieldNotation
+							hasPrivateScope && options.useEsprivateFieldNotation
 								? `#${name}`
 								: name;
 
@@ -237,7 +237,7 @@ export async function convertDiToInjectGenerator(
 							name: propertyName,
 							initializer,
 							scope:
-								hasPrivateScope && options.useESPrivateFieldNotation
+								hasPrivateScope && options.useEsprivateFieldNotation
 									? null
 									: scope,
 							isReadonly:
@@ -333,7 +333,7 @@ export async function convertDiToInjectGenerator(
 				}
 			});
 
-			if (options.useESPrivateFieldNotation) {
+			if (options.useEsprivateFieldNotation) {
 				Array.from(convertedPrivateDeps).forEach((convertedDepsName) => {
 					const startIndex = targetClass.getProperties().length;
 					const tempAddedProperty = targetClass.insertProperty(startIndex, {

--- a/libs/plugin/src/generators/convert-di-to-inject/schema.d.ts
+++ b/libs/plugin/src/generators/convert-di-to-inject/schema.d.ts
@@ -2,5 +2,5 @@ export interface ConvertDiToInjectGeneratorSchema {
 	project?: string;
 	path?: string;
 	includeReadonlyByDefault?: boolean;
-	useESPrivateFieldNotation?: boolean;
+	useEsprivateFieldNotation?: boolean;
 }

--- a/libs/plugin/src/generators/convert-di-to-inject/schema.json
+++ b/libs/plugin/src/generators/convert-di-to-inject/schema.json
@@ -18,8 +18,13 @@
 			"aliases": ["includeReadonly", "includeReadonlyByDefault"],
 			"description": "Whether to include readonly for injections by default. Default is false."
 		},
-		"useESPrivateFieldNotation": {
+		"useEsprivateFieldNotation": {
 			"type": "boolean",
+			"aliases": [
+				"useESPrivateFieldNotation",
+				"useEsprivateFieldNotation",
+				"useEsPrivateFieldNotation"
+			],
 			"description": "Whether to replace TS private modifier with ES private field notation. Default is false."
 		}
 	}


### PR DESCRIPTION
For the "inject-di-migration", a new option "useESPrivateFieldNotation" was added to support replacing TS "private" properties with ES private field properties.

However, an issue is found when executing the generator with the newly added option, and it's because of the option's name, "useESPrivateFieldNotation".

## Running with Angular CLI
When running the schematic in a plain Angular app, i.e through Angular CLI with the "--help" option to get more insights about the schematic itself, we get the following:

<img width="1262" alt="ng-cli generator options" src="https://github.com/ngxtension/ngxtension-platform/assets/24731032/fc2ff577-e7e9-41a7-b01f-a0bb703a38ce">
Listed as the last one, besides the alias name provided in **schema json** , ngCLI also generates another, default alias: dash-separated name ( **--use-esprivate-field-notation** ).


Till now it's ok. but when we execute the schematic to do the work it's intended to and check the **options** at runtime, you can see that neither the alias nor the option name in the schema is being used:

<img width="1261" alt="ng-cli options at runtime" src="https://github.com/ngxtension/ngxtension-platform/assets/24731032/1d7d1b18-55be-4ad4-ae89-f864e127ac88">

As you can notice, the original name option, "useESPrivateFieldNotation" is **undefined**, and ngCLI has created another option under the hood, "useEsprivateFieldNotation", which is the same as the original option name but with "...ESP..." subsection in lowercase:

                               useESPrivateFieldNotation -> useEsprivateFieldNotation

Because of this when running with Angular CLI, the schematic never applied the feature offered with that option.

## Running with Nx

If you check the same config of the generator with Nx, there are no extra aliases generated, and naming is non-sensitive:

<img width="1345" alt="Screen Shot 2024-06-03 at 09 43 35" src="https://github.com/ngxtension/ngxtension-platform/assets/24731032/8e58d61a-58f4-4315-a29a-e05fadacdf5c">

and the generator executes normally, see the options at runtime:

<img width="979" alt="Screen Shot 2024-06-03 at 09 44 25" src="https://github.com/ngxtension/ngxtension-platform/assets/24731032/154cebaf-67c2-4a09-b70e-25cece9071d2">

## The fix

Use the same alias as the initial option name, but just update the option name internally at the source code.

