### PR TITLE
Fix: new logo paths

### DIFF
--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -4,8 +4,10 @@ template: splash
 hero:
   tagline: Una colección de utilidades para Angular.
   image:
-    file: ../../../../public/logo.svg
     alt: ngxtension logo
+    file: ../../../../public/ngxt-blue.svg
+    dark: ../../../../public/ngxt-white.png
+    light: ../../../../public/ngxt-blue.png
 
   actions:
     - text: Inicio

--- a/docs/src/content/docs/logos/logos.md
+++ b/docs/src/content/docs/logos/logos.md
@@ -3,18 +3,18 @@ title: Press Kit
 ---
 
 <div style="display: grid; align-items: center; justify-items: center; gap: 1em; grid-template-columns: repeat(2, 1fr)">
-    <img src="../public/ngxt-angular.svg">
-    <img src="../public/ngxt-blue.svg">
-    <img src="../public/ngxt-black.svg">
+    <img src="../../../../public/ngxt-angular.svg">
+    <img src="../../../../public/ngxt-blue.svg">
+    <img src="../../../../public/ngxt-black.svg">
     <div style="background: black; padding: 10px">
-        <img src="../public/ngxt-white.svg">
+        <img src="../../../../public/ngxt-white.svg">
     </div>
 </div>
 <div style="display: grid; align-items: center; justify-items: center; gap: 1em; grid-template-columns: 1fr 1fr">
-    <img src="../public/ngxtension-angular.svg">
-    <img src="../public/ngxtension-blue.svg">
-    <img src="../public/ngxtension-black.svg">
+    <img src="../../../../public/ngxtension-angular.svg">
+    <img src="../../../../public/ngxtension-blue.svg">
+    <img src="../../../../public/ngxtension-black.svg">
     <div style="background: black; padding: 10px">
-        <img src="../public/ngxtension-white.svg">
+        <img src="../../../../public/ngxtension-white.svg">
     </div>
 </div>


### PR DESCRIPTION
This is two similar but separate things

- The Press Kit images were 404'ing while deployed. However, for some reason they resolved fine when ran locally. WSL magic, caching, not sure. Anyways, they are now pointed to work locally and also I would assume as deployed.
- The Spanish main page was still pointing at the old logo. 

