### PR TITLE
feat(to-observable-signal): refactor toObservableSignal to handle Obs…

### DIFF
--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.spec.ts
@@ -1,5 +1,6 @@
 import { Injector, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, of } from 'rxjs';
 import { toObservableSignal } from './to-observable-signal';
 
 describe('toObservableSignal()', () => {
@@ -23,6 +24,36 @@ describe('toObservableSignal()', () => {
 
 		const injector = TestBed.inject(Injector);
 		const observableSignal = toObservableSignal(s, { injector });
+
+		expect(observableSignal.subscribe).toBeDefined();
+		expect(observableSignal.pipe).toBeDefined();
+		expect((observableSignal as any)['set']).toBeUndefined();
+		expect((observableSignal as any)['update']).toBeUndefined();
+		expect((observableSignal as any)['asReadonly']).toBeUndefined();
+		expect(typeof observableSignal).toEqual('function');
+		expect(observableSignal()).toEqual('Hello');
+	});
+
+	it('should return a <Signal & Observable> when input is Observable', () => {
+		const obs = of<string>('Hello');
+
+		const injector = TestBed.inject(Injector);
+		const observableSignal = toObservableSignal(obs, { injector });
+
+		expect(observableSignal.subscribe).toBeDefined();
+		expect(observableSignal.pipe).toBeDefined();
+		expect((observableSignal as any)['set']).toBeUndefined();
+		expect((observableSignal as any)['update']).toBeUndefined();
+		expect((observableSignal as any)['asReadonly']).toBeUndefined();
+		expect(typeof observableSignal).toEqual('function');
+		expect(observableSignal()).toEqual('Hello');
+	});
+
+	it('should return a <Signal & Observable> when input is Subscribable', () => {
+		const obs = new BehaviorSubject<string>('Hello');
+
+		const injector = TestBed.inject(Injector);
+		const observableSignal = toObservableSignal(obs, { injector });
 
 		expect(observableSignal.subscribe).toBeDefined();
 		expect(observableSignal.pipe).toBeDefined();
@@ -59,5 +90,18 @@ describe('toObservableSignal()', () => {
 			expect(value).toBe('World');
 			done();
 		});
+	});
+
+	it('should emit the updated value when the original obs changes', () => {
+		const obs = new BehaviorSubject<string>('Hello');
+
+		const injector = TestBed.inject(Injector);
+		const observableSignal = toObservableSignal(obs, { injector });
+
+		obs.next('World');
+		TestBed.flushEffects();
+
+		expect(typeof observableSignal).toEqual('function');
+		expect(observableSignal()).toEqual('World');
 	});
 });

--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
@@ -1,6 +1,7 @@
 import {
 	assertInInjectionContext,
 	isDevMode,
+	isSignal,
 	type Signal,
 	type WritableSignal,
 } from '@angular/core';
@@ -14,16 +15,16 @@ import type { Observable, Subscribable } from 'rxjs';
 export type ObservableSignal<T> = Signal<T> & Observable<T>;
 
 export function toObservableSignal<T>(
-	s: WritableSignal<T> | Observable<T> | Subscribable<T>,
+	s: WritableSignal<T> | Subscribable<T>,
 	options?: ToObservableOptions,
 ): WritableSignal<T> & Observable<T>;
 export function toObservableSignal<T>(
-	s: Signal<T> | Observable<T> | Subscribable<T>,
+	s: Signal<T> | Subscribable<T>,
 	options?: ToObservableOptions,
 ): ObservableSignal<T>;
 
 export function toObservableSignal<T>(
-	source: Signal<T> | Observable<T> | Subscribable<T>,
+	source: Signal<T> | Subscribable<T>,
 	options?: ToObservableOptions,
 ) {
 	if (isDevMode() && !options?.injector) {
@@ -31,13 +32,13 @@ export function toObservableSignal<T>(
 	}
 
 	let s: Signal<T | undefined>;
-	let obs: Observable<T>;
+	let obs: Subscribable<T>;
 
-	if (typeof source === 'function') {
-		s = source as Signal<T>;
+	if (isSignal(source)) {
+		s = source;
 		obs = toObservable(source as Signal<T>, options);
 	} else {
-		obs = source as unknown as Observable<T>;
+		obs = source;
 		s = toSignal(obs, { injector: options?.injector });
 	}
 

--- a/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
+++ b/libs/ngxtension/to-observable-signal/src/to-observable-signal.ts
@@ -6,30 +6,40 @@ import {
 } from '@angular/core';
 import {
 	toObservable,
+	toSignal,
 	type ToObservableOptions,
 } from '@angular/core/rxjs-interop';
-import type { Observable } from 'rxjs';
+import type { Observable, Subscribable } from 'rxjs';
 
 export type ObservableSignal<T> = Signal<T> & Observable<T>;
 
 export function toObservableSignal<T>(
-	s: WritableSignal<T>,
+	s: WritableSignal<T> | Observable<T> | Subscribable<T>,
 	options?: ToObservableOptions,
 ): WritableSignal<T> & Observable<T>;
 export function toObservableSignal<T>(
-	s: Signal<T>,
+	s: Signal<T> | Observable<T> | Subscribable<T>,
 	options?: ToObservableOptions,
 ): ObservableSignal<T>;
 
 export function toObservableSignal<T>(
-	s: Signal<T>,
+	source: Signal<T> | Observable<T> | Subscribable<T>,
 	options?: ToObservableOptions,
 ) {
 	if (isDevMode() && !options?.injector) {
 		assertInInjectionContext(toObservableSignal);
 	}
 
-	const obs = toObservable(s, options);
+	let s: Signal<T | undefined>;
+	let obs: Observable<T>;
+
+	if (typeof source === 'function') {
+		s = source as Signal<T>;
+		obs = toObservable(source as Signal<T>, options);
+	} else {
+		obs = source as unknown as Observable<T>;
+		s = toSignal(obs, { injector: options?.injector });
+	}
 
 	return new Proxy(s, {
 		get(_, prop) {


### PR DESCRIPTION
…ervables and Subscribables

The refactor allows toObservableSignal to handle Observables and Subscribables, expanding its flexibility and usage. It introduces the ability to convert an Observable or Subscribable to a Signal & Observable, enhancing its adaptability. This change aims to improve the overall functionality of toObservableSignal by broadening its capabilities.