### PR TITLE
fix(signal-input-migration): preserve line endings

### DIFF
--- a/libs/plugin/src/generators/shared-utils/migrate-signals-in-template.ts
+++ b/libs/plugin/src/generators/shared-utils/migrate-signals-in-template.ts
@@ -16,6 +16,7 @@ export function migrateTemplateVariablesToSignals(
 		template,
 		'template.html',
 		{
+      preserveLineEndings: true,
 			tokenizeBlocks: true,
 		},
 	);


### PR DESCRIPTION
Without this change the text contained in `value` will be shorter than `end - start` if it contains `\r\n`, since all the `\r` characters will be stripped out. This causes the change offset to be wrong for all subsequent changes.