### PR TITLE
fix: Press Kit links

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,8 +6,8 @@ hero:
   image:
     alt: ngxtension logo
     file: ../../../public/ngxt-blue.svg
-    dark: ../../../public/ngxt-white.png
-    light: ../../../public/ngxt-blue.png
+    dark: ../../../public/ngxt-white.svg
+    light: ../../../public/ngxt-blue.svg
 
   actions:
     - text: Getting Started

--- a/docs/src/content/docs/logos/logos.md
+++ b/docs/src/content/docs/logos/logos.md
@@ -3,18 +3,18 @@ title: Press Kit
 ---
 
 <div style="display: grid; align-items: center; justify-items: center; gap: 1em; grid-template-columns: repeat(2, 1fr)">
-    <img src="../../../../public/ngxt-angular.svg">
-    <img src="../../../../public/ngxt-blue.svg">
-    <img src="../../../../public/ngxt-black.svg">
+    <img src="../../../../ngxt-angular.svg">
+    <img src="../../../../ngxt-blue.svg">
+    <img src="../../../../ngxt-black.svg">
     <div style="background: black; padding: 10px">
-        <img src="../../../../public/ngxt-white.svg">
+        <img src="../../../../ngxt-white.svg">
     </div>
 </div>
 <div style="display: grid; align-items: center; justify-items: center; gap: 1em; grid-template-columns: 1fr 1fr">
-    <img src="../../../../public/ngxtension-angular.svg">
-    <img src="../../../../public/ngxtension-blue.svg">
-    <img src="../../../../public/ngxtension-black.svg">
+    <img src="../../../../ngxtension-angular.svg">
+    <img src="../../../../ngxtension-blue.svg">
+    <img src="../../../../ngxtension-black.svg">
     <div style="background: black; padding: 10px">
-        <img src="../../../../public/ngxtension-white.svg">
+        <img src="../../../../ngxtension-white.svg">
     </div>
 </div>


### PR DESCRIPTION
closes #411 

I believe the broken links came from the addition of `public` to the URL path.  

I built the docs with the updated links and on `preview`, the images were displayed.  

Sidenote: Github Codespaces has an older `pnpm` version installed so I downleveled to that versus updating `pnpm`.  I would think this shouldn't be problem in the near future.    