### PR TITLE
Enhance inject route utilities

### DIFF
--- a/docs/src/content/docs/es/utilities/Injectors/inject-route-fragment.md
+++ b/docs/src/content/docs/es/utilities/Injectors/inject-route-fragment.md
@@ -31,7 +31,7 @@ class TestComponent implements OnInit {
 
 	ngOnInit() {
 		const isFragmentAvailable: Signal<boolean> = injectRouteFragment({
-			transform: (fragment) => !!fragment,
+			parse: (fragment) => !!fragment,
 			injector: this.injector,
 		});
 	}

--- a/docs/src/content/docs/utilities/Injectors/inject-params.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-params.md
@@ -16,7 +16,9 @@ import { injectParams } from 'ngxtension/inject-params';
 
 ## Usage
 
-`injectParams` when is called, returns a signal with the current route params.
+### Get all route params
+
+`injectParams` returns a signal with the current route params.
 
 ```ts
 @Component({
@@ -28,12 +30,25 @@ class TestComponent {
 }
 ```
 
+#### Transform all params
+
+Or, if we want to transform the params, we can pass a function to `injectParams`.
+
+```ts
+@Component()
+class TestComponent {
+	paramsKeys = injectParams((params) => Object.keys(params)); // returns a signal with the keys of the params
+}
+```
+
+### Specific param
+
 If we want to get the value for a specific param, we can pass the name of the param to `injectParams`.
 
 ```ts
 @Component({
 	template: `
-		@if (user()) {
+		@if (user(); as user) {
 			<div>{{ user.name }}</div>
 		} @else {
 			<div>No user!</div>
@@ -50,11 +65,52 @@ class TestComponent {
 }
 ```
 
-Or, if we want to transform the params, we can pass a function to `injectParams`.
+#### Transform
+
+If you want to additional parse the specific param, we can pass a `parse` function.
 
 ```ts
-@Component()
+@Component({
+	template: `
+		@if (user(); as user) {
+			<div>{{ user.name }}</div>
+		} @else {
+			<div>No user!</div>
+		}
+	`,
+})
 class TestComponent {
-	paramsKeys = injectParams((params) => Object.keys(params)); // returns a signal with the keys of the params
+	userId = injectParams('id', { parse: numberAttribute }); // returns a signal with the value of the id param parsed to a number
+
+	user = derivedFrom(
+		[this.userId],
+		switchMap((id) => this.userService.getUser(id).pipe(startWith(null))),
+	);
+}
+```
+
+#### Default value
+
+If we want to use a default value if there is no value, we can pass a `defaultValue`.
+
+```ts
+@Component({
+	template: `
+		@if (angular(); as angular) {
+			<div>{{ angular.name }}</div>
+		} @else {
+			<div>No Angular version found!</div>
+		}
+	`,
+})
+class TestComponent {
+	angularVersion = injectParams('version', { defaultValue: '19' }); // returns a signal with the value of the id param parsed to a number
+
+	angular = derivedFrom(
+		[this.angularVersion],
+		switchMap((version) =>
+			this.angularService.getAngular(version).pipe(startWith(null)),
+		),
+	);
 }
 ```

--- a/docs/src/content/docs/utilities/Injectors/inject-params.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-params.md
@@ -67,7 +67,7 @@ class TestComponent {
 
 #### Transform
 
-If you want to additional parse the specific param, we can pass a `parse` function.
+If you want to parse the specific param, you can pass a `parse` function.
 
 ```ts
 @Component({

--- a/docs/src/content/docs/utilities/Injectors/inject-query-params.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-query-params.md
@@ -62,7 +62,7 @@ import { injectQueryParams } from 'ngxtension/inject-query-params';
 	template: `
 		Search results for: {{ searchParam() }}
 
-		@for (user of filteredUsers()) {
+		@for (user of filteredUsers(); track user.id) {
 			<div>{{ user.name }}</div>
 		} @empty {
 			<div>No users!</div>
@@ -79,7 +79,7 @@ class TestComponent {
 }
 ```
 
-If we want to additional transform the value into any shape, we can pass a `transform` function.
+If we want to additional parse the value into any shape, we can pass a `parse` function.
 
 ```ts
 // Example url: /users?pageNumber=1
@@ -92,13 +92,13 @@ import { injectQueryParams } from 'ngxtension/inject-query-params';
 	`,
 })
 class TestComponent {
-	pageNumber = injectQueryParams('pageNumber', { transform: numberAttribute });
+	pageNumber = injectQueryParams('pageNumber', { parse: numberAttribute });
 
 	multipliedNumber = computed(() => this.pageNumber() * 2);
 }
 ```
 
-If we want to use a default value if there is no value, we can pass a `initialValue`.
+If we want to use a default value if there is no value, we can pass a `defaultValue`.
 
 ```ts
 // Example urls producing the same output: "/users?search=nartc", "/users"
@@ -109,7 +109,7 @@ import { injectQueryParams } from 'ngxtension/inject-query-params';
 	template: `
 		Search results for: {{ searchParam() }}
 
-		@for (user of filteredUsers()) {
+		@for (user of filteredUsers(); track user.id) {
 			<div>{{ user.name }}</div>
 		} @empty {
 			<div>No users!</div>
@@ -118,7 +118,7 @@ import { injectQueryParams } from 'ngxtension/inject-query-params';
 })
 class TestComponent {
 	// returns a signal with the value of the search query param or '' if not provided.
-	searchParam = injectQueryParams('search', { initialValue: 'nartc' });
+	searchParam = injectQueryParams('search', { defaultValue: 'nartc' });
 
 	filteredUsers = derivedAsync(
 		() => this.userService.getUsers(this.searchParam()),
@@ -179,9 +179,9 @@ import { injectQueryParams } from 'ngxtension/inject-query-params';
 })
 class TestComponent {
 	productService = inject(ProductService);
-	// returns a signal with the array values of the product query param and transform each value
+	// returns a signal with the array values of the product query param and parse each value
 	productIds = injectQueryParams.array('productIds', {
-		transform: numberAttribute,
+		parse: numberAttribute,
 	});
 
 	products = derivedAsync(
@@ -191,7 +191,7 @@ class TestComponent {
 }
 ```
 
-If we want to use a default value if there are no values, we can pass a `initialValue`.
+If we want to use a default value if there are no values, we can pass a `defaultValue`.
 
 ```ts
 // Example urls producing the same output: "/search?products=Angular", "/search"
@@ -213,7 +213,7 @@ class TestComponent {
 	productService = inject(ProductService);
 	// returns a signal with the array values of the product query param or 'Angular' if the user provides none
 	productNames = injectQueryParams.array('products', {
-		initialValue: ['Angular'],
+		defaultValue: ['Angular'],
 	});
 
 	products = derivedAsync(

--- a/docs/src/content/docs/utilities/Injectors/inject-route-data.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-route-data.md
@@ -27,6 +27,17 @@ class TestComponent {
 }
 ```
 
+Or, if we want to transform the data, we can pass a function to `injectRouteData`.
+
+```ts
+@Component()
+class TestComponent {
+	routeDataKeys = injectRouteData((data) => Object.keys(data)); // returns a signal with the keys of the route data object
+}
+```
+
+### Specific value
+
 If we want to get the value for a specific key, we can pass the name of the object key to `injectRouteData`.
 
 ```ts
@@ -37,15 +48,28 @@ If we want to get the value for a specific key, we can pass the name of the obje
 	`,
 })
 class TestComponent {
-	details = injectRouteData('details'); // returns a signal with the value of the details key in route data object
+	details: Signal<unknown> = injectRouteData('details'); // returns a signal with the value of the details key in route data object
 }
 ```
 
-Or, if we want to transform the data, we can pass a function to `injectRouteData`.
+You can also pass a custom injector or `defaultValue`.
 
 ```ts
 @Component()
-class TestComponent {
-	routeDataKeys = injectRouteData((data) => Object.keys(data)); // returns a signal with the keys of the route data object
+class TestComponent implements OnInit {
+	injector = inject(Injector);
+
+	detailsWithDefaultValue: Signal<string> = injectRouteData('details', {
+		defaultValue: 'abc',
+	});
+
+	ngOnInit() {
+		const detailsWithCustomInjector: Signal<boolean> = injectRouteData(
+			'details',
+			{
+				injector: this.injector,
+			},
+		);
+	}
 }
 ```

--- a/docs/src/content/docs/utilities/Injectors/inject-route-fragment.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-route-fragment.md
@@ -18,20 +18,24 @@ import { injectRouteFragment } from 'ngxtension/inject-route-fragment';
 ```ts
 @Component(...)
 class TestComponent {
-  fragment = injectRouteFragment();
+  fragment: Signal<string | null> = injectRouteFragment();
 }
 ```
 
-You can pass transform function or custom injector.
+You can pass a `parse` function, custom injector or `defaultValue`.
 
 ```ts
 @Component()
 class TestComponent implements OnInit {
 	injector = inject(Injector);
 
+	fragmentNotNull: Signal<string> = injectRouteFragment({
+		defaultValue: 'abc',
+	});
+
 	ngOnInit() {
 		const isFragmentAvailable: Signal<boolean> = injectRouteFragment({
-			transform: (fragment) => !!fragment,
+			parse: (fragment) => !!fragment,
 			injector: this.injector,
 		});
 	}

--- a/libs/ngxtension/inject-params/src/inject-params.spec.ts
+++ b/libs/ngxtension/inject-params/src/inject-params.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, numberAttribute } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { provideRouter } from '@angular/router';
@@ -30,6 +30,34 @@ describe(injectParams.name, () => {
 		expect(instance.userId()).toEqual('test');
 		expect(instance.paramKeysList()).toEqual(['id']);
 	});
+
+	it('returns a signal everytime the route params change based on the param id and transform option', async () => {
+		TestBed.configureTestingModule({
+			providers: [
+				provideRouter([
+					{ path: 'post/:id', component: PostComponent },
+					{ path: 'post', component: PostComponent },
+				]),
+			],
+		});
+
+		const harness = await RouterTestingHarness.create();
+
+		const instanceNull = await harness.navigateByUrl('/post', PostComponent);
+
+		expect(instanceNull.postId()).toEqual(null);
+		expect(instanceNull.postIdDefault()).toEqual(69);
+
+		const instance = await harness.navigateByUrl('/post/420', PostComponent);
+
+		expect(instance.postId()).toEqual(420);
+		expect(instance.postIdDefault()).toEqual(420);
+
+		await harness.navigateByUrl('/post/test', PostComponent);
+
+		expect(instance.postId()).toEqual(NaN);
+		expect(instance.postIdDefault()).toEqual(NaN);
+	});
 });
 
 @Component({
@@ -40,4 +68,16 @@ export class UserProfileComponent {
 	params = injectParams();
 	userId = injectParams('id');
 	paramKeysList = injectParams((params) => Object.keys(params));
+}
+
+@Component({
+	standalone: true,
+	template: ``,
+})
+export class PostComponent {
+	postId = injectParams('id', { transform: numberAttribute });
+	postIdDefault = injectParams('id', {
+		transform: numberAttribute,
+		defaultValue: 69,
+	});
 }

--- a/libs/ngxtension/inject-params/src/inject-params.spec.ts
+++ b/libs/ngxtension/inject-params/src/inject-params.spec.ts
@@ -93,9 +93,9 @@ export class UserProfileComponent {
 	template: ``,
 })
 export class PostComponent {
-	postId = injectParams('id', { transform: numberAttribute });
+	postId = injectParams('id', { parse: numberAttribute });
 	postIdDefault = injectParams('id', {
-		transform: numberAttribute,
+		parse: numberAttribute,
 		defaultValue: 69,
 	});
 }

--- a/libs/ngxtension/inject-params/src/inject-params.spec.ts
+++ b/libs/ngxtension/inject-params/src/inject-params.spec.ts
@@ -1,4 +1,10 @@
-import { Component, numberAttribute } from '@angular/core';
+import {
+	Component,
+	inject,
+	Injector,
+	numberAttribute,
+	Signal,
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { provideRouter } from '@angular/router';
@@ -22,12 +28,14 @@ describe(injectParams.name, () => {
 
 		expect(instance.params()).toEqual({ id: 'angular' });
 		expect(instance.userId()).toEqual('angular');
+		expect(instance.userIdCustomInjector!()).toEqual('angular');
 		expect(instance.paramKeysList()).toEqual(['id']);
 
 		await harness.navigateByUrl('/user/test', UserProfileComponent);
 
 		expect(instance.params()).toEqual({ id: 'test' });
 		expect(instance.userId()).toEqual('test');
+		expect(instance.userIdCustomInjector!()).toEqual('test');
 		expect(instance.paramKeysList()).toEqual(['id']);
 	});
 
@@ -65,9 +73,19 @@ describe(injectParams.name, () => {
 	template: ``,
 })
 export class UserProfileComponent {
+	private _injector = inject(Injector);
+
 	params = injectParams();
 	userId = injectParams('id');
 	paramKeysList = injectParams((params) => Object.keys(params));
+
+	userIdCustomInjector?: Signal<string | null>;
+
+	constructor() {
+		this.userIdCustomInjector = injectParams('id', {
+			injector: this._injector,
+		});
+	}
 }
 
 @Component({

--- a/libs/ngxtension/inject-params/src/inject-params.ts
+++ b/libs/ngxtension/inject-params/src/inject-params.ts
@@ -5,7 +5,7 @@ import { assertInjector } from 'ngxtension/assert-injector';
 import {
 	DefaultValueOptions,
 	InjectorOptions,
-	TransformOptions,
+	ParseOptions,
 } from 'ngxtension/shared';
 import { map } from 'rxjs';
 
@@ -18,7 +18,7 @@ type ParamsTransformFn<ReadT> = (params: Params) => ReadT;
  * @template WriteT - The type of the value to be written.
  * @template DefaultValueT - The type of the default value.
  */
-export type ParamsOptions<ReadT, WriteT, DefaultValueT> = TransformOptions<
+export type ParamsOptions<ReadT, WriteT, DefaultValueT> = ParseOptions<
 	ReadT,
 	WriteT
 > &
@@ -91,7 +91,7 @@ export function injectParams<T>(
 	return assertInjector(injectParams, options?.injector, () => {
 		const route = inject(ActivatedRoute);
 		const params = route.snapshot.params;
-		const { transform, defaultValue } = options;
+		const { parse, defaultValue } = options;
 
 		if (!keyOrParamsTransform) {
 			return toSignal(route.params, { initialValue: params });
@@ -110,7 +110,7 @@ export function injectParams<T>(
 				return defaultValue ?? null;
 			}
 
-			return transform ? transform(param) : param;
+			return parse ? parse(param) : param;
 		};
 
 		return toSignal(route.params.pipe(map(getParam)), {

--- a/libs/ngxtension/inject-params/src/inject-params.ts
+++ b/libs/ngxtension/inject-params/src/inject-params.ts
@@ -1,24 +1,95 @@
-import { assertInInjectionContext, inject, type Signal } from '@angular/core';
+import { inject, type Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, type Params } from '@angular/router';
+import { assertInjector } from 'ngxtension/assert-injector';
+import {
+	DefaultValueOptions,
+	InjectorOptions,
+	TransformOptions,
+} from 'ngxtension/shared';
 import { map } from 'rxjs';
 
+type ParamsTransformFn<ReadT> = (params: Params) => ReadT;
+
 /**
- * Injects the params from the current route.
+ * The `ParamsOptions` type defines options for configuring the behavior of the `injectParams` function.
+ *
+ * @template ReadT - The expected type of the read value.
+ * @template WriteT - The type of the value to be written.
+ * @template DefaultValueT - The type of the default value.
+ */
+export type ParamsOptions<ReadT, WriteT, DefaultValueT> = TransformOptions<
+	ReadT,
+	WriteT
+> &
+	DefaultValueOptions<DefaultValueT> &
+	InjectorOptions;
+
+/**
+ * The `injectParams` function allows you to access and manipulate parameters from the current route.
+ *
+ * @returns A `Signal` that emits the entire parameters object.
  */
 export function injectParams(): Signal<Params>;
 
 /**
- * Injects the params from the current route and returns the value of the provided key.
- * @param key
+ * The `injectParams` function allows you to access and manipulate parameters from the current route.
+ *
+ * @param {string} key - The name of the parameter to retrieve.
+ * @returns {Signal} A `Signal` that emits the value of the specified parameter, or `null` if it's not present.
  */
 export function injectParams(key: string): Signal<string | null>;
 
 /**
- * Injects the params from the current route and returns the result of the provided transform function.
- * @param transform
+ * The `injectParams` function allows you to access and manipulate parameters from the current route.
+ *
+ * @param {string} key - The name of the parameter to retrieve.
+ * @param {ParamsOptions} options - Optional configuration options for the parameter.
+ * @returns {Signal} A `Signal` that emits the transformed value of the specified parameter, or `null` if it's not present.
  */
-export function injectParams<T>(transform: (params: Params) => T): Signal<T>;
+export function injectParams(
+	key?: string,
+	options?: ParamsOptions<boolean, string, boolean>,
+): Signal<boolean | null>;
+
+/**
+ * The `injectParams` function allows you to access and manipulate parameters from the current route.
+ *
+ * @param {string} key - The name of the parameter to retrieve.
+ * @param {ParamsOptions} options - Optional configuration options for the parameter.
+ * @returns {Signal} A `Signal` that emits the transformed value of the specified parameter, or `null` if it's not present.
+ */
+export function injectParams(
+	key?: string,
+	options?: ParamsOptions<number, string, number>,
+): Signal<number | null>;
+
+/**
+ * The `injectParams` function allows you to access and manipulate parameters from the current route.
+ *
+ * @param {string} key - The name of the parameter to retrieve.
+ * @param {ParamsOptions} options - Optional configuration options for the parameter.
+ * @returns {Signal} A `Signal` that emits the transformed value of the specified parameter, or `null` if it's not present.
+ */
+export function injectParams(
+	key?: string,
+	options?: ParamsOptions<string, string, string>,
+): Signal<string | null>;
+
+/**
+ * The `injectParams` function allows you to access and manipulate parameters from the current route.
+ * It retrieves the value of a parameter based on a custom transform function applied to the parameters object.
+ *
+ * @template ReadT - The expected type of the read value.
+ * @param {ParamsTransformFn<ReadT>} fn - A transform function that takes the parameters object (`params: Params`) and returns the desired value.
+ * @returns {Signal} A `Signal` that emits the transformed value based on the provided custom transform function.
+ *
+ * @example
+ * const searchValue = injectParams((params) => params['search'] as string);
+ */
+export function injectParams<ReadT>(
+	fn: ParamsTransformFn<ReadT>,
+): Signal<ReadT>;
 
 /**
  * Injects the params from the current route.
@@ -26,30 +97,48 @@ export function injectParams<T>(transform: (params: Params) => T): Signal<T>;
  * If a transform function is provided, it will return the result of that function.
  * Otherwise, it will return the entire params object.
  *
+ * @template T - The expected type of the read value.
+ * @param keyOrParamsTransform OPTIONAL The key of the param to return, or a transform function to apply to the params object
+ * @param {ParamsOptions} options - Optional configuration options for the parameter.
+ * @returns {Signal} A `Signal` that emits the transformed value of the specified parameter, or the entire parameters object if no key is provided.
+ *
  * @example
  * const userId = injectParams('id'); // returns the value of the 'id' param
  * const userId = injectParams(p => p['id'] as string); // same as above but can be used with a custom transform function
  * const params = injectParams(); // returns the entire params object
  *
- * @param keyOrTransform OPTIONAL The key of the param to return, or a transform function to apply to the params object
  */
 export function injectParams<T>(
-	keyOrTransform?: string | ((params: Params) => T),
+	keyOrParamsTransform?: string | ((params: Params) => T),
+	options: ParamsOptions<T, string, T> = {},
 ): Signal<T | Params | string | null> {
-	assertInInjectionContext(injectParams);
-	const route = inject(ActivatedRoute);
-	const params = route.snapshot.params;
+	return assertInjector(injectParams, options?.injector, () => {
+		const route = inject(ActivatedRoute);
+		const params = route.snapshot.params;
+		const { transform, defaultValue } = options;
 
-	if (typeof keyOrTransform === 'function') {
-		return toSignal(route.params.pipe(map(keyOrTransform)), {
-			initialValue: keyOrTransform(params),
+		if (!keyOrParamsTransform) {
+			return toSignal(route.params, { initialValue: params });
+		}
+
+		if (typeof keyOrParamsTransform === 'function') {
+			return toSignal(route.params.pipe(map(keyOrParamsTransform)), {
+				initialValue: keyOrParamsTransform(params),
+			});
+		}
+
+		const getParam = (params: Params) => {
+			const param = params?.[keyOrParamsTransform] as string | undefined;
+
+			if (!param) {
+				return defaultValue ?? null;
+			}
+
+			return transform ? transform(param) : param;
+		};
+
+		return toSignal(route.params.pipe(map(getParam)), {
+			initialValue: getParam(params),
 		});
-	}
-
-	const getParam = (params: Params) =>
-		keyOrTransform ? (params?.[keyOrTransform] ?? null) : params;
-
-	return toSignal(route.params.pipe(map(getParam)), {
-		initialValue: getParam(params),
 	});
 }

--- a/libs/ngxtension/inject-params/src/inject-params.ts
+++ b/libs/ngxtension/inject-params/src/inject-params.ts
@@ -47,34 +47,10 @@ export function injectParams(key: string): Signal<string | null>;
  * @param {ParamsOptions} options - Optional configuration options for the parameter.
  * @returns {Signal} A `Signal` that emits the transformed value of the specified parameter, or `null` if it's not present.
  */
-export function injectParams(
+export function injectParams<ReadT>(
 	key?: string,
-	options?: ParamsOptions<boolean, string, boolean>,
-): Signal<boolean | null>;
-
-/**
- * The `injectParams` function allows you to access and manipulate parameters from the current route.
- *
- * @param {string} key - The name of the parameter to retrieve.
- * @param {ParamsOptions} options - Optional configuration options for the parameter.
- * @returns {Signal} A `Signal` that emits the transformed value of the specified parameter, or `null` if it's not present.
- */
-export function injectParams(
-	key?: string,
-	options?: ParamsOptions<number, string, number>,
-): Signal<number | null>;
-
-/**
- * The `injectParams` function allows you to access and manipulate parameters from the current route.
- *
- * @param {string} key - The name of the parameter to retrieve.
- * @param {ParamsOptions} options - Optional configuration options for the parameter.
- * @returns {Signal} A `Signal` that emits the transformed value of the specified parameter, or `null` if it's not present.
- */
-export function injectParams(
-	key?: string,
-	options?: ParamsOptions<string, string, string>,
-): Signal<string | null>;
+	options?: ParamsOptions<ReadT, string, ReadT>,
+): Signal<ReadT | null>;
 
 /**
  * The `injectParams` function allows you to access and manipulate parameters from the current route.

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
@@ -1,4 +1,10 @@
-import { Component, numberAttribute } from '@angular/core';
+import {
+	Component,
+	inject,
+	Injector,
+	numberAttribute,
+	Signal,
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { provideRouter } from '@angular/router';
@@ -10,13 +16,17 @@ import { injectQueryParams } from './inject-query-params';
 	template: ``,
 })
 export class SearchComponent {
+	private _injector = inject(Injector);
+
 	queryParams = injectQueryParams();
 	idParam = injectQueryParams('id', { transform: numberAttribute });
+	idParamCustomInjector?: Signal<number | null>;
 	idParamDefault = injectQueryParams('id', {
 		transform: numberAttribute,
 		defaultValue: 420,
 	});
 	idParams = injectQueryParams.array('id', { transform: numberAttribute });
+	idParamsCustomInjector?: Signal<number[] | null>;
 	idParamsDefault = injectQueryParams.array('id', {
 		transform: numberAttribute,
 		defaultValue: [420, 69],
@@ -24,10 +34,25 @@ export class SearchComponent {
 	searchParam = injectQueryParams('query');
 	searchParamDefault = injectQueryParams('query', { defaultValue: 'React' });
 	searchParams = injectQueryParams.array('query');
+	searchParamsCustomInjector?: Signal<string[] | null>;
 	searchParamsDefault = injectQueryParams.array('query', {
 		defaultValue: ['React', 'Vue'],
 	});
 	paramKeysList = injectQueryParams((params) => Object.keys(params));
+
+	constructor() {
+		this.idParamCustomInjector = injectQueryParams('id', {
+			transform: numberAttribute,
+			injector: this._injector,
+		});
+		this.idParamsCustomInjector = injectQueryParams.array('id', {
+			transform: numberAttribute,
+			injector: this._injector,
+		});
+		this.searchParamsCustomInjector = injectQueryParams.array('query', {
+			injector: this._injector,
+		});
+	}
 }
 
 describe(injectQueryParams.name, () => {
@@ -51,6 +76,7 @@ describe(injectQueryParams.name, () => {
 		expect(instance.searchParam()).toEqual('Angular');
 		expect(instance.searchParamDefault()).toEqual('Angular');
 		expect(instance.idParam()).toEqual(null);
+		expect(instance.idParamCustomInjector!()).toEqual(null);
 		expect(instance.idParamDefault()).toEqual(420);
 		expect(instance.paramKeysList()).toEqual(['query']);
 
@@ -58,6 +84,7 @@ describe(injectQueryParams.name, () => {
 
 		expect(instance.queryParams()).toEqual({ query: 'IsCool!', id: '2' });
 		expect(instance.idParam()).toEqual(2);
+		expect(instance.idParamCustomInjector!()).toEqual(2);
 		expect(instance.idParamDefault()).toEqual(2);
 		expect(instance.searchParam()).toEqual('IsCool!');
 		expect(instance.searchParamDefault()).toEqual('IsCool!');
@@ -164,6 +191,10 @@ describe(injectQueryParams.array.name, () => {
 
 		expect(instance.queryParams()).toEqual({ query: ['Angular', 'Analog'] });
 		expect(instance.searchParams()).toEqual(['Angular', 'Analog']);
+		expect(instance.searchParamsCustomInjector!()).toEqual([
+			'Angular',
+			'Analog',
+		]);
 		expect(instance.searchParamsDefault()).toEqual(['Angular', 'Analog']);
 		expect(instance.idParams()).toEqual(null);
 		expect(instance.idParamsDefault()).toEqual([420, 69]);
@@ -176,8 +207,13 @@ describe(injectQueryParams.array.name, () => {
 			id: '2',
 		});
 		expect(instance.idParams()).toEqual([2]);
+		expect(instance.idParamsCustomInjector!()).toEqual([2]);
 		expect(instance.idParamsDefault()).toEqual([2]);
 		expect(instance.searchParams()).toEqual(['IsCool!', 'IsNotCool']);
+		expect(instance.searchParamsCustomInjector!()).toEqual([
+			'IsCool!',
+			'IsNotCool',
+		]);
 		expect(instance.searchParamsDefault()).toEqual(['IsCool!', 'IsNotCool']);
 		expect(instance.paramKeysList()).toEqual(['query', 'id']);
 	});
@@ -199,6 +235,7 @@ describe(injectQueryParams.array.name, () => {
 
 		expect(instance.queryParams()).toEqual({ id: ['2.2', '5'] });
 		expect(instance.idParams()).toEqual([2.2, 5]);
+		expect(instance.idParamsCustomInjector!()).toEqual([2.2, 5]);
 		expect(instance.idParamsDefault()).toEqual([2.2, 5]);
 		expect(instance.paramKeysList()).toEqual(['id']);
 	});

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
@@ -12,9 +12,21 @@ import { injectQueryParams } from './inject-query-params';
 export class SearchComponent {
 	queryParams = injectQueryParams();
 	idParam = injectQueryParams('id', { transform: numberAttribute });
+	idParamDefault = injectQueryParams('id', {
+		transform: numberAttribute,
+		defaultValue: 420,
+	});
 	idParams = injectQueryParams.array('id', { transform: numberAttribute });
+	idParamsDefault = injectQueryParams.array('id', {
+		transform: numberAttribute,
+		defaultValue: [420, 69],
+	});
 	searchParam = injectQueryParams('query');
+	searchParamDefault = injectQueryParams('query', { defaultValue: 'React' });
 	searchParams = injectQueryParams.array('query');
+	searchParamsDefault = injectQueryParams.array('query', {
+		defaultValue: ['React', 'Vue'],
+	});
 	paramKeysList = injectQueryParams((params) => Object.keys(params));
 }
 
@@ -37,14 +49,18 @@ describe(injectQueryParams.name, () => {
 
 		expect(instance.queryParams()).toEqual({ query: 'Angular' });
 		expect(instance.searchParam()).toEqual('Angular');
+		expect(instance.searchParamDefault()).toEqual('Angular');
 		expect(instance.idParam()).toEqual(null);
+		expect(instance.idParamDefault()).toEqual(420);
 		expect(instance.paramKeysList()).toEqual(['query']);
 
 		await harness.navigateByUrl('/search?query=IsCool!&id=2');
 
 		expect(instance.queryParams()).toEqual({ query: 'IsCool!', id: '2' });
 		expect(instance.idParam()).toEqual(2);
+		expect(instance.idParamDefault()).toEqual(2);
 		expect(instance.searchParam()).toEqual('IsCool!');
+		expect(instance.searchParamDefault()).toEqual('IsCool!');
 		expect(instance.paramKeysList()).toEqual(['query', 'id']);
 	});
 
@@ -58,12 +74,14 @@ describe(injectQueryParams.name, () => {
 
 		expect(instance.queryParams()).toEqual({ id: 'Angular' });
 		expect(instance.idParam()).toEqual(NaN);
+		expect(instance.idParamDefault()).toEqual(NaN);
 		expect(instance.paramKeysList()).toEqual(['id']);
 
 		await harness.navigateByUrl('/search?&id=2.2');
 
 		expect(instance.queryParams()).toEqual({ id: '2.2' });
 		expect(instance.idParam()).toEqual(2.2);
+		expect(instance.idParamDefault()).toEqual(2.2);
 		expect(instance.paramKeysList()).toEqual(['id']);
 	});
 
@@ -76,8 +94,15 @@ describe(injectQueryParams.name, () => {
 
 		expect(instance.queryParams()).toEqual({ query: 'Angular' });
 		expect(instance.searchParam()).toEqual('Angular');
+		expect(instance.searchParamDefault()).toEqual('Angular');
 		expect(instance.idParam()).toEqual(null);
+		expect(instance.idParamDefault()).toEqual(420);
 		expect(instance.paramKeysList()).toEqual(['query']);
+
+		await harness.navigateByUrl('/search', SearchComponent);
+
+		expect(instance.searchParam()).toEqual(null);
+		expect(instance.searchParamDefault()).toEqual('React');
 	});
 
 	it('returns a signal for numeric query parameters', async () => {
@@ -89,6 +114,7 @@ describe(injectQueryParams.name, () => {
 
 		expect(instance.queryParams()).toEqual({ id: '42' });
 		expect(instance.idParam()).toEqual(42);
+		expect(instance.idParamDefault()).toEqual(42);
 		expect(instance.paramKeysList()).toEqual(['id']);
 	});
 
@@ -101,6 +127,7 @@ describe(injectQueryParams.name, () => {
 
 		expect(instance.queryParams()).toEqual({ query: 'Hello World' });
 		expect(instance.searchParam()).toEqual('Hello World');
+		expect(instance.searchParamDefault()).toEqual('Hello World');
 		expect(instance.paramKeysList()).toEqual(['query']);
 	});
 
@@ -113,6 +140,7 @@ describe(injectQueryParams.name, () => {
 
 		expect(instance.queryParams()).toEqual({ query: 'Angular' });
 		expect(instance.searchParam()).toEqual('Angular');
+		expect(instance.searchParamDefault()).toEqual('Angular');
 		expect(instance.paramKeysList()).toEqual(['query']);
 	});
 });
@@ -136,7 +164,9 @@ describe(injectQueryParams.array.name, () => {
 
 		expect(instance.queryParams()).toEqual({ query: ['Angular', 'Analog'] });
 		expect(instance.searchParams()).toEqual(['Angular', 'Analog']);
+		expect(instance.searchParamsDefault()).toEqual(['Angular', 'Analog']);
 		expect(instance.idParams()).toEqual(null);
+		expect(instance.idParamsDefault()).toEqual([420, 69]);
 		expect(instance.paramKeysList()).toEqual(['query']);
 
 		await harness.navigateByUrl('/search?query=IsCool!&query=IsNotCool&id=2');
@@ -146,7 +176,9 @@ describe(injectQueryParams.array.name, () => {
 			id: '2',
 		});
 		expect(instance.idParams()).toEqual([2]);
+		expect(instance.idParamsDefault()).toEqual([2]);
 		expect(instance.searchParams()).toEqual(['IsCool!', 'IsNotCool']);
+		expect(instance.searchParamsDefault()).toEqual(['IsCool!', 'IsNotCool']);
 		expect(instance.paramKeysList()).toEqual(['query', 'id']);
 	});
 
@@ -160,12 +192,14 @@ describe(injectQueryParams.array.name, () => {
 
 		expect(instance.queryParams()).toEqual({ id: ['Angular', 'Analog'] });
 		expect(instance.idParams()).toEqual([NaN, NaN]);
+		expect(instance.idParamsDefault()).toEqual([NaN, NaN]);
 		expect(instance.paramKeysList()).toEqual(['id']);
 
 		await harness.navigateByUrl('/search?&id=2.2&id=5');
 
 		expect(instance.queryParams()).toEqual({ id: ['2.2', '5'] });
 		expect(instance.idParams()).toEqual([2.2, 5]);
+		expect(instance.idParamsDefault()).toEqual([2.2, 5]);
 		expect(instance.paramKeysList()).toEqual(['id']);
 	});
 
@@ -175,7 +209,9 @@ describe(injectQueryParams.array.name, () => {
 
 		expect(instance.queryParams()).toEqual({});
 		expect(instance.searchParam()).toEqual(null);
+		expect(instance.searchParamDefault()).toEqual('React');
 		expect(instance.idParam()).toEqual(null);
+		expect(instance.idParamDefault()).toEqual(420);
 		expect(instance.paramKeysList()).toEqual([]);
 	});
 

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.spec.ts
@@ -19,16 +19,16 @@ export class SearchComponent {
 	private _injector = inject(Injector);
 
 	queryParams = injectQueryParams();
-	idParam = injectQueryParams('id', { transform: numberAttribute });
+	idParam = injectQueryParams('id', { parse: numberAttribute });
 	idParamCustomInjector?: Signal<number | null>;
 	idParamDefault = injectQueryParams('id', {
-		transform: numberAttribute,
+		parse: numberAttribute,
 		defaultValue: 420,
 	});
-	idParams = injectQueryParams.array('id', { transform: numberAttribute });
+	idParams = injectQueryParams.array('id', { parse: numberAttribute });
 	idParamsCustomInjector?: Signal<number[] | null>;
 	idParamsDefault = injectQueryParams.array('id', {
-		transform: numberAttribute,
+		parse: numberAttribute,
 		defaultValue: [420, 69],
 	});
 	searchParam = injectQueryParams('query');
@@ -42,11 +42,11 @@ export class SearchComponent {
 
 	constructor() {
 		this.idParamCustomInjector = injectQueryParams('id', {
-			transform: numberAttribute,
+			parse: numberAttribute,
 			injector: this._injector,
 		});
 		this.idParamsCustomInjector = injectQueryParams.array('id', {
-			transform: numberAttribute,
+			parse: numberAttribute,
 			injector: this._injector,
 		});
 		this.searchParamsCustomInjector = injectQueryParams.array('query', {
@@ -64,7 +64,7 @@ describe(injectQueryParams.name, () => {
 		});
 	});
 
-	it('returns a signal everytime the query params change based on the param passed to the fn and transform fn', async () => {
+	it('returns a signal everytime the query params change based on the param passed to the fn and parse fn', async () => {
 		const harness = await RouterTestingHarness.create();
 
 		const instance = await harness.navigateByUrl(
@@ -158,7 +158,7 @@ describe(injectQueryParams.name, () => {
 		expect(instance.paramKeysList()).toEqual(['query']);
 	});
 
-	it('returns a signal for query parameters with no transform', async () => {
+	it('returns a signal for query parameters with no parse', async () => {
 		const harness = await RouterTestingHarness.create();
 		const instance = await harness.navigateByUrl(
 			'/search?query=Angular',
@@ -181,7 +181,7 @@ describe(injectQueryParams.array.name, () => {
 		});
 	});
 
-	it('returns a signal everytime the query params change based on the param passed to the fn and transform fn', async () => {
+	it('returns a signal everytime the query params change based on the param passed to the fn and parse fn', async () => {
 		const harness = await RouterTestingHarness.create();
 
 		const instance = await harness.navigateByUrl(
@@ -330,7 +330,7 @@ describe(injectQueryParams.array.name, () => {
 		expect(instance.searchParams()).toEqual(['Hello World', 'Hi There']);
 	});
 
-	it('returns a signal for array query parameters with no transform', async () => {
+	it('returns a signal for array query parameters with no parse', async () => {
 		const harness = await RouterTestingHarness.create();
 		const instance = await harness.navigateByUrl(
 			'/search?query=Angular&query=React',

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.ts
@@ -5,7 +5,7 @@ import { assertInjector } from 'ngxtension/assert-injector';
 import {
 	DefaultValueOptions,
 	InjectorOptions,
-	TransformOptions,
+	ParseOptions,
 } from 'ngxtension/shared';
 import { map } from 'rxjs';
 
@@ -18,16 +18,26 @@ type QueryParamsTransformFn<ReadT> = (params: Params) => ReadT;
  * @template WriteT - The type of the value to be written.
  * @template DefaultValueT - The type of the default value.
  */
-export type QueryParamsOptions<ReadT, WriteT, DefaultValueT> = TransformOptions<
+export type QueryParamsOptions<ReadT, DefaultValueT> = ParseOptions<
 	ReadT,
-	WriteT
+	string | null
 > &
 	DefaultValueOptions<DefaultValueT> &
 	InjectorOptions & {
 		/**
 		 * The initial value to use if the query parameter is not present or undefined.
+		 *
+		 * @deprecated Use `defaultValue` as a replacement.
 		 */
 		initialValue?: DefaultValueT;
+		/**
+		 * A transformation function to convert the written value to the expected read value.
+		 *
+		 * @deprecated Use `parse` as a replacement.
+		 * @param v - The value to transform.
+		 * @returns The transformed value.
+		 */
+		transform?: (v: string | null) => ReadT;
 	};
 
 /**
@@ -54,7 +64,7 @@ export function injectQueryParams(key: string): Signal<string | null>;
  */
 export function injectQueryParams<ReadT>(
 	key?: string,
-	options?: QueryParamsOptions<ReadT, string, ReadT>,
+	options?: QueryParamsOptions<ReadT, ReadT>,
 ): Signal<ReadT | null>;
 
 /**
@@ -76,26 +86,26 @@ export function injectQueryParams<ReadT>(
  * The `injectQueryParams` function allows you to access and manipulate query parameters from the current route.
  *
  * @template ReadT - The expected type of the read value.
- * @param {string} keyOrParamsTransform - The name of the query parameter to retrieve, or a transform function to apply to the query parameters object.
+ * @param {string} keyOrParamsTransform - The name of the query parameter to retrieve, or a parse function to apply to the query parameters object.
  * @param {QueryParamsOptions} options - Optional configuration options for the query parameter.
- * @returns {Signal} A `Signal` that emits the transformed value of the specified query parameter, or the entire query parameters object if no key is provided.
+ * @returns {Signal} A `Signal` that emits the parsed value of the specified query parameter, or the entire query parameters object if no key is provided.
  *
  * @example
  * const search = injectQueryParams('search'); // returns the value of the 'search' query param
- * const search = injectQueryParams(p => p['search'] as string); // same as above but can be used with a custom transform function
- * const idParam = injectQueryParams('id', {transform: numberAttribute}); // returns the value fo the 'id' query params and transforms it into a number
+ * const search = injectQueryParams(p => p['search'] as string); // same as above but can be used with a custom parse function
+ * const idParam = injectQueryParams('id', {parse: numberAttribute}); // returns the value fo the 'id' query params and parses it into a number
  * const idParam = injectQueryParams(p => numberAttribute(p['id'])); // same as above but can be used with a custom transform function
  * const queryParams = injectQueryParams(); // returns the entire query params object
  */
 export function injectQueryParams<ReadT>(
 	keyOrParamsTransform?: string | ((params: Params) => ReadT),
-	options: QueryParamsOptions<ReadT, string, ReadT> = {},
+	options: QueryParamsOptions<ReadT, ReadT> = {},
 ): Signal<ReadT | Params | string | boolean | number | null> {
 	return assertInjector(injectQueryParams, options?.injector, () => {
 		const route = inject(ActivatedRoute);
 		const queryParams = route.snapshot.queryParams || {};
 
-		const { transform, initialValue, defaultValue } = options;
+		const { parse, transform, initialValue, defaultValue } = options;
 
 		if (!keyOrParamsTransform) {
 			return toSignal(route.queryParams, { initialValue: queryParams });
@@ -121,10 +131,14 @@ export function injectQueryParams<ReadT>(
 				if (param.length < 1) {
 					return defaultValue ?? initialValue ?? null;
 				}
-				return transform ? transform(param[0]) : param[0];
+				return parse
+					? parse(param[0])
+					: transform
+						? transform(param[0])
+						: param[0];
 			}
 
-			return transform ? transform(param) : param;
+			return parse ? parse(param) : transform ? transform(param) : param;
 		};
 
 		return toSignal(route.queryParams.pipe(map(getParam)), {
@@ -146,7 +160,7 @@ export namespace injectQueryParams {
 	 */
 	export function array(
 		key: string,
-		options?: QueryParamsOptions<string, string, string[]>,
+		options?: QueryParamsOptions<string, string[]>,
 	): Signal<string[] | null>;
 
 	/**
@@ -158,7 +172,7 @@ export namespace injectQueryParams {
 	 */
 	export function array<ReadT>(
 		key: string,
-		options?: QueryParamsOptions<ReadT, string, ReadT[]>,
+		options?: QueryParamsOptions<ReadT, ReadT[]>,
 	): Signal<ReadT[] | null>;
 
 	/**
@@ -171,13 +185,13 @@ export namespace injectQueryParams {
 	 */
 	export function array<ReadT>(
 		key: string,
-		options: QueryParamsOptions<ReadT, string, ReadT[]> = {},
+		options: QueryParamsOptions<ReadT, ReadT[]> = {},
 	): Signal<(ReadT | string)[] | null> {
 		return assertInjector(injectQueryParams.array, options?.injector, () => {
 			const route = inject(ActivatedRoute);
 			const queryParams = route.snapshot.queryParams || {};
 
-			const { transform, initialValue, defaultValue } = options;
+			const { parse, transform, initialValue, defaultValue } = options;
 
 			const transformParam = (
 				param: string | string[] | null,
@@ -189,15 +203,19 @@ export namespace injectQueryParams {
 					if (param.length < 1) {
 						return defaultValue ?? initialValue ?? null;
 					}
-					// Avoid passing the transform function directly into the map function,
-					// because transform may inadvertently use the array index as its second argument.
+					// Avoid passing the parse function directly into the map function,
+					// because parse may inadvertently use the array index as its second argument.
 					// Typically, map provides the array index as the second argument to its callback,
-					// which can conflict with transform functions like numberAttribute that expect a fallbackValue as their second parameter.
+					// which can conflict with parse functions like numberAttribute that expect a fallbackValue as their second parameter.
 					// This mismatch can lead to unexpected behavior, such as values being erroneously converted to array indices
 					// instead of NaN (which would be correct)
-					return transform ? param.map((it) => transform(it)) : param;
+					return parse
+						? param.map((it) => parse(it))
+						: transform
+							? param.map((it) => transform(it))
+							: param;
 				}
-				return [transform ? transform(param) : param];
+				return [parse ? parse(param) : transform ? transform(param) : param];
 			};
 
 			const getParam = (params: Params) => {

--- a/libs/ngxtension/inject-query-params/src/inject-query-params.ts
+++ b/libs/ngxtension/inject-query-params/src/inject-query-params.ts
@@ -52,34 +52,10 @@ export function injectQueryParams(key: string): Signal<string | null>;
  * @param {QueryParamsOptions} options - Optional configuration options for the query parameter.
  * @returns {Signal} A `Signal` that emits the transformed value of the specified query parameter, or `null` if it's not present.
  */
-export function injectQueryParams(
+export function injectQueryParams<ReadT>(
 	key?: string,
-	options?: QueryParamsOptions<boolean, string, boolean>,
-): Signal<boolean | null>;
-
-/**
- * The `injectQueryParams` function allows you to access and manipulate query parameters from the current route.
- *
- * @param {string} key - The name of the query parameter to retrieve.
- * @param {QueryParamsOptions} options - Optional configuration options for the query parameter.
- * @returns {Signal} A `Signal` that emits the transformed value of the specified query parameter, or `null` if it's not present.
- */
-export function injectQueryParams(
-	key?: string,
-	options?: QueryParamsOptions<number, string, number>,
-): Signal<number | null>;
-
-/**
- * The `injectQueryParams` function allows you to access and manipulate query parameters from the current route.
- *
- * @param {string} key - The name of the query parameter to retrieve.
- * @param {QueryParamsOptions} options - Optional configuration options for the query parameter.
- * @returns {Signal} A `Signal` that emits the transformed value of the specified query parameter, or `null` if it's not present.
- */
-export function injectQueryParams(
-	key?: string,
-	options?: QueryParamsOptions<string, string, string>,
-): Signal<string | null>;
+	options?: QueryParamsOptions<ReadT, string, ReadT>,
+): Signal<ReadT | null>;
 
 /**
  * The `injectQueryParams` function allows you to access and manipulate query parameters from the current route.
@@ -170,32 +146,20 @@ export namespace injectQueryParams {
 	 */
 	export function array(
 		key: string,
-		options?: QueryParamsOptions<boolean, string, boolean[]>,
-	): Signal<boolean[] | null>;
-
-	/**
-	 * Retrieve an array query parameter with optional configuration options.
-	 *
-	 * @param {string} key - The name of the array query parameter to retrieve.
-	 * @param {QueryParamsOptions} options - Optional configuration options for the array query parameter.
-	 * @returns {Signal} A `Signal` that emits an array of values for the specified query parameter, or `null` if it's not present.
-	 */
-	export function array(
-		key: string,
-		options?: QueryParamsOptions<number, string, number[]>,
-	): Signal<number[] | null>;
-
-	/**
-	 * Retrieve an array query parameter with optional configuration options.
-	 *
-	 * @param {string} key - The name of the array query parameter to retrieve.
-	 * @param {QueryParamsOptions} options - Optional configuration options for the array query parameter.
-	 * @returns {Signal} A `Signal` that emits an array of values for the specified query parameter, or `null` if it's not present.
-	 */
-	export function array(
-		key: string,
 		options?: QueryParamsOptions<string, string, string[]>,
 	): Signal<string[] | null>;
+
+	/**
+	 * Retrieve an array query parameter with optional configuration options.
+	 *
+	 * @param {string} key - The name of the array query parameter to retrieve.
+	 * @param {QueryParamsOptions} options - Optional configuration options for the array query parameter.
+	 * @returns {Signal} A `Signal` that emits an array of values for the specified query parameter, or `null` if it's not present.
+	 */
+	export function array<ReadT>(
+		key: string,
+		options?: QueryParamsOptions<ReadT, string, ReadT[]>,
+	): Signal<ReadT[] | null>;
 
 	/**
 	 * Retrieve an array query parameter with optional configuration options.
@@ -217,7 +181,7 @@ export namespace injectQueryParams {
 
 			const transformParam = (
 				param: string | string[] | null,
-			): (string | ReadT)[] | null => {
+			): (ReadT | string)[] | null => {
 				if (!param) {
 					return defaultValue ?? initialValue ?? null;
 				}

--- a/libs/ngxtension/inject-route-data/src/inject-route-data.ts
+++ b/libs/ngxtension/inject-route-data/src/inject-route-data.ts
@@ -29,9 +29,13 @@ export function injectRouteData(): Signal<Data>;
  *
  * @template T - The expected type of the read value.
  * @param {string} key - The name of the route data to retrieve.
+ * @param {RouteDataOptions} options - Optional configuration options for the route data.
  * @returns {Signal} A `Signal` that emits the value of the specified route data, or `null` if it's not present.
  */
-export function injectRouteData<T>(key: keyof Data): Signal<T | null>;
+export function injectRouteData<T>(
+	key: keyof Data,
+	options?: RouteDataOptions<T>,
+): Signal<T | null>;
 
 /**
  * The `injectRouteData` function allows you to access and manipulate route data from the current route.
@@ -39,6 +43,7 @@ export function injectRouteData<T>(key: keyof Data): Signal<T | null>;
  *
  * @template T - The expected type of the read value.
  * @param {RouteDataTransformFn<T>} fn - A transform function that takes the route data object and returns the desired value.
+ * @param {RouteDataOptions} options - Optional configuration options for the route data.
  * @returns {Signal<T>} A `Signal` that emits the transformed value based on the provided custom transform function.
  *
  * @example
@@ -46,6 +51,7 @@ export function injectRouteData<T>(key: keyof Data): Signal<T | null>;
  */
 export function injectRouteData<ReadT>(
 	fn: RouteDataTransformFn<ReadT>,
+	options?: RouteDataOptions<ReadT>,
 ): Signal<ReadT>;
 
 export function injectRouteData<T>(

--- a/libs/ngxtension/inject-route-data/src/inject-route-data.ts
+++ b/libs/ngxtension/inject-route-data/src/inject-route-data.ts
@@ -1,48 +1,80 @@
-import { assertInInjectionContext, inject, type Signal } from '@angular/core';
+import { inject, type Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, type Data } from '@angular/router';
+import { assertInjector } from 'ngxtension/assert-injector';
+import { DefaultValueOptions, InjectorOptions } from 'ngxtension/shared';
 import { map } from 'rxjs';
 
 type RouteDataTransformFn<T> = (data: Data) => T;
 
 /**
- * The `injectRouteData` function allows you to access and manipulate data from the current route.
+ * The `RouteDataOptions` type defines options for configuring the behavior of the `injectRouteData` function.
  *
- * @returns {Signal} A `Signal` that emits the entire route data object.
+ * @template ReadT - The expected type of the read value.
+ * @template WriteT - The type of the value to be written.
+ * @template DefaultValueT - The type of the default value.
+ */
+export type RouteDataOptions<DefaultValueT> =
+	DefaultValueOptions<DefaultValueT> & InjectorOptions;
+
+/**
+ * The `injectRouteData` function allows you to access and manipulate route data from the current route.
+ *
+ * @returns A `Signal` that emits the entire data object.
  */
 export function injectRouteData(): Signal<Data>;
 
 /**
- * The `injectRouteData` function allows you to access and manipulate data from the current route.
- * @param {string} key - The name of the route data object key to retrieve.
- * @returns {Signal} A `Signal` that emits the value of the specified route data object key
+ * The `injectRouteData` function allows you to access and manipulate route data from the current route.
+ *
+ * @template T - The expected type of the read value.
+ * @param {string} key - The name of the route data to retrieve.
+ * @returns {Signal} A `Signal` that emits the value of the specified route data, or `null` if it's not present.
  */
 export function injectRouteData<T>(key: keyof Data): Signal<T | null>;
 
 /**
- * The `injectQueryParams` function allows you to access and manipulate query parameters from the current route.
+ * The `injectRouteData` function allows you to access and manipulate route data from the current route.
+ * It retrieves the value of the route data based on a custom transform function applied to the route data object.
  *
- * @param {RouteDataTransformFn} transform - The name of the query parameter to retrieve.
- * @returns {Signal} A `Signal` that emits the transformed value of the specified route data object key.
+ * @template T - The expected type of the read value.
+ * @param {RouteDataTransformFn<T>} fn - A transform function that takes the route data object and returns the desired value.
+ * @returns {Signal<T>} A `Signal` that emits the transformed value based on the provided custom transform function.
+ *
+ * @example
+ * const searchValue = injectRouteData((data) => data['search'] as string);
  */
-export function injectRouteData<T>(
-	transform: RouteDataTransformFn<T>,
-): Signal<T>;
+export function injectRouteData<ReadT>(
+	fn: RouteDataTransformFn<ReadT>,
+): Signal<ReadT>;
 
 export function injectRouteData<T>(
-	keyOrTransform?: keyof Data | ((data: Data) => T),
+	keyOrTransform?: keyof Data | RouteDataTransformFn<T>,
+	options: RouteDataOptions<T> = {},
 ) {
-	assertInInjectionContext(injectRouteData);
-	const route = inject(ActivatedRoute);
-	const initialRouteData = route.snapshot.data || {};
+	return assertInjector(injectRouteData, options?.injector, () => {
+		const route = inject(ActivatedRoute);
+		const initialRouteData = route.snapshot.data || {};
+		const { defaultValue } = options;
 
-	const getDataParam =
-		typeof keyOrTransform === 'function'
-			? keyOrTransform
-			: (data: Data) =>
-					keyOrTransform ? (data?.[keyOrTransform] ?? null) : data;
+		if (!keyOrTransform) {
+			return toSignal(route.data, { initialValue: initialRouteData });
+		}
 
-	return toSignal(route.data.pipe(map(getDataParam)), {
-		initialValue: getDataParam(initialRouteData),
+		if (typeof keyOrTransform === 'function') {
+			return toSignal(route.data.pipe(map(keyOrTransform)), {
+				initialValue: keyOrTransform(initialRouteData),
+			});
+		}
+
+		const getDataParam = (data: Data) => {
+			const param = data?.[keyOrTransform] as unknown | undefined;
+
+			return param ?? defaultValue ?? null;
+		};
+
+		return toSignal(route.data.pipe(map(getDataParam)), {
+			initialValue: getDataParam(initialRouteData),
+		});
 	});
 }

--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
@@ -1,11 +1,21 @@
-import { Component, inject, Injector, OnInit, Signal } from '@angular/core';
+import {
+	booleanAttribute,
+	Component,
+	inject,
+	Injector,
+	numberAttribute,
+	OnInit,
+	Signal,
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { injectRouteFragment } from './inject-route-fragment';
 
 describe(injectRouteFragment.name, () => {
-	it('returns a signal everytime the route fragment changed', async () => {
+	let harness: RouterTestingHarness;
+
+	beforeEach(async () => {
 		TestBed.configureTestingModule({
 			providers: [
 				provideRouter([
@@ -17,8 +27,10 @@ describe(injectRouteFragment.name, () => {
 			],
 		});
 
-		const harness = await RouterTestingHarness.create();
+		harness = await RouterTestingHarness.create();
+	});
 
+	it('returns a signal everytime the route fragment changed', async () => {
 		const instance = await harness.navigateByUrl('test', TestComponent);
 
 		expect(instance.fragment()).toEqual(null);
@@ -37,6 +49,66 @@ describe(injectRouteFragment.name, () => {
 		}
 		expect(instance.isFragmentAvailable()).toEqual(true);
 	});
+
+	it('returns a signal everytime the route fragment changed with default value', async () => {
+		const instance = await harness.navigateByUrl('test', TestComponent);
+
+		expect(instance.fragmentDefaultValue()).toEqual('default-fragment');
+		expect(instance.fragmentDefaultValueFromCustomInjector).not.toBeNull();
+		if (instance.fragmentDefaultValueFromCustomInjector) {
+			expect(instance.fragmentDefaultValueFromCustomInjector()).toEqual(
+				'default-fragment',
+			);
+		}
+		expect(instance.numberFragmentDefaultValue()).toEqual(100);
+
+		await harness.navigateByUrl('test#sample-fragment', TestComponent);
+
+		expect(instance.fragmentDefaultValue()).toEqual('sample-fragment');
+		expect(instance.fragmentDefaultValueFromCustomInjector).not.toBeNull();
+		if (instance.fragmentDefaultValueFromCustomInjector) {
+			expect(instance.fragmentDefaultValueFromCustomInjector()).toEqual(
+				'sample-fragment',
+			);
+		}
+		expect(instance.numberFragmentDefaultValue()).toEqual(NaN);
+
+		await harness.navigateByUrl('test#100000000', TestComponent);
+
+		expect(instance.numberFragmentDefaultValue()).toEqual(100000000);
+	});
+
+	it('returns right signals and values for different transformers', async () => {
+		const instance = await harness.navigateByUrl('test', TestComponent);
+
+		expect(instance.fragment()).toEqual(null);
+		expect(instance.numberFragment()).toEqual(NaN);
+		expect(instance.booleanFragment()).toEqual(false);
+
+		await harness.navigateByUrl('test#sample-fragment', TestComponent);
+
+		expect(instance.fragment()).toEqual('sample-fragment');
+		expect(instance.numberFragment()).toEqual(NaN);
+		expect(instance.booleanFragment()).toEqual(true);
+
+		await harness.navigateByUrl('test#1234', TestComponent);
+
+		expect(instance.fragment()).toEqual('1234');
+		expect(instance.numberFragment()).toEqual(1234);
+		expect(instance.booleanFragment()).toEqual(true);
+
+		await harness.navigateByUrl('test#true', TestComponent);
+
+		expect(instance.fragment()).toEqual('true');
+		expect(instance.numberFragment()).toEqual(NaN);
+		expect(instance.booleanFragment()).toEqual(true);
+
+		await harness.navigateByUrl('test#false', TestComponent);
+
+		expect(instance.fragment()).toEqual('false');
+		expect(instance.numberFragment()).toEqual(NaN);
+		expect(instance.booleanFragment()).toEqual(false);
+	});
 });
 
 @Component({
@@ -46,13 +118,27 @@ describe(injectRouteFragment.name, () => {
 export class TestComponent implements OnInit {
 	private _injector = inject(Injector);
 	fragment = injectRouteFragment();
+	numberFragment = injectRouteFragment({ transform: numberAttribute });
+	numberFragmentDefaultValue = injectRouteFragment({
+		transform: numberAttribute,
+		defaultValue: 100,
+	});
+	booleanFragment = injectRouteFragment({ transform: booleanAttribute });
+	fragmentDefaultValue = injectRouteFragment({
+		defaultValue: 'default-fragment',
+	});
 	isFragmentAvailable = injectRouteFragment({
 		transform: (fragment) => !!fragment,
 	});
 	fragmentFromCustomInjector: Signal<string | null> | null = null;
+	fragmentDefaultValueFromCustomInjector: Signal<string | null> | null = null;
 
-	ngOnInit() {
+	ngOnInit(): void {
 		this.fragmentFromCustomInjector = injectRouteFragment({
+			injector: this._injector,
+		});
+		this.fragmentDefaultValueFromCustomInjector = injectRouteFragment({
+			defaultValue: 'default-fragment',
 			injector: this._injector,
 		});
 	}

--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.spec.ts
@@ -78,7 +78,7 @@ describe(injectRouteFragment.name, () => {
 		expect(instance.numberFragmentDefaultValue()).toEqual(100000000);
 	});
 
-	it('returns right signals and values for different transformers', async () => {
+	it('returns right signals and values for different parsers', async () => {
 		const instance = await harness.navigateByUrl('test', TestComponent);
 
 		expect(instance.fragment()).toEqual(null);
@@ -118,17 +118,17 @@ describe(injectRouteFragment.name, () => {
 export class TestComponent implements OnInit {
 	private _injector = inject(Injector);
 	fragment = injectRouteFragment();
-	numberFragment = injectRouteFragment({ transform: numberAttribute });
+	numberFragment = injectRouteFragment({ parse: numberAttribute });
 	numberFragmentDefaultValue = injectRouteFragment({
-		transform: numberAttribute,
+		parse: numberAttribute,
 		defaultValue: 100,
 	});
-	booleanFragment = injectRouteFragment({ transform: booleanAttribute });
+	booleanFragment = injectRouteFragment({ parse: booleanAttribute });
 	fragmentDefaultValue = injectRouteFragment({
 		defaultValue: 'default-fragment',
 	});
 	isFragmentAvailable = injectRouteFragment({
-		transform: (fragment) => !!fragment,
+		parse: (fragment) => !!fragment,
 	});
 	fragmentFromCustomInjector: Signal<string | null> | null = null;
 	fragmentDefaultValueFromCustomInjector: Signal<string | null> | null = null;

--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
@@ -1,23 +1,25 @@
-import { inject, type Injector, type Signal } from '@angular/core';
+import { inject, type Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { assertInjector } from 'ngxtension/assert-injector';
+import {
+	DefaultValueOptions,
+	InjectorOptions,
+	TransformOptions,
+} from 'ngxtension/shared';
 import { map } from 'rxjs';
 
-export interface InjectRouteFragmentOptions<T = unknown> {
-	/**
-	 * A transformation function.
-	 *
-	 * @param fragment - The fragment value to transform.
-	 * @returns The transformed value.
-	 */
-	transform?: (fragment: string | null) => T;
-
-	/**
-	 * The optional "custom" Injector. If this is not provided, will be retrieved from the current injection context
-	 */
-	injector?: Injector;
-}
+/**
+ * The `InjectRouteFragmentOptions` type defines options for configuring the behavior of the `injectRouteFragment` function.
+ *
+ * @template T - The expected type of the read value.
+ */
+export type InjectRouteFragmentOptions<T = unknown> = TransformOptions<
+	T,
+	string | null
+> &
+	InjectorOptions &
+	DefaultValueOptions<T>;
 
 /**
  * The `injectRouteFragment` function allows you to access and transform url fragment from the current route.
@@ -43,7 +45,13 @@ export function injectRouteFragment<T>(
 		const route = inject(ActivatedRoute);
 		const initialRouteFragment = route.snapshot.fragment;
 		const getFragment = (fragment: string | null) => {
-			if (options?.transform) return options.transform(fragment);
+			if (fragment === null && options?.defaultValue) {
+				return options.defaultValue;
+			}
+			if (options?.transform) {
+				return options.transform(fragment);
+			}
+
 			return fragment;
 		};
 		const fragment$ = route.fragment.pipe(map(getFragment));

--- a/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
+++ b/libs/ngxtension/inject-route-fragment/src/inject-route-fragment.ts
@@ -5,7 +5,7 @@ import { assertInjector } from 'ngxtension/assert-injector';
 import {
 	DefaultValueOptions,
 	InjectorOptions,
-	TransformOptions,
+	ParseOptions,
 } from 'ngxtension/shared';
 import { map } from 'rxjs';
 
@@ -14,12 +14,21 @@ import { map } from 'rxjs';
  *
  * @template T - The expected type of the read value.
  */
-export type InjectRouteFragmentOptions<T = unknown> = TransformOptions<
+export type InjectRouteFragmentOptions<T = unknown> = ParseOptions<
 	T,
 	string | null
 > &
 	InjectorOptions &
-	DefaultValueOptions<T>;
+	DefaultValueOptions<T> & {
+		/**
+		 * A transformation function to convert the written value to the expected read value.
+		 *
+		 * @deprecated Use `parse` as a replacement.
+		 * @param v - The value to transform.
+		 * @returns The transformed value.
+		 */
+		transform?: (v: string | null) => T;
+	};
 
 /**
  * The `injectRouteFragment` function allows you to access and transform url fragment from the current route.
@@ -47,6 +56,9 @@ export function injectRouteFragment<T>(
 		const getFragment = (fragment: string | null) => {
 			if (fragment === null && options?.defaultValue) {
 				return options.defaultValue;
+			}
+			if (options?.parse) {
+				return options.parse(fragment);
 			}
 			if (options?.transform) {
 				return options.transform(fragment);

--- a/libs/ngxtension/shared/README.md
+++ b/libs/ngxtension/shared/README.md
@@ -1,0 +1,3 @@
+# ngxtension/shared
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/shared`.

--- a/libs/ngxtension/shared/ng-package.json
+++ b/libs/ngxtension/shared/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/shared/project.json
+++ b/libs/ngxtension/shared/project.json
@@ -1,0 +1,27 @@
+{
+	"name": "ngxtension/shared",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/shared/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["shared"],
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/shared/src/index.ts
+++ b/libs/ngxtension/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './options';

--- a/libs/ngxtension/shared/src/options/default-value.ts
+++ b/libs/ngxtension/shared/src/options/default-value.ts
@@ -1,0 +1,6 @@
+export type DefaultValueOptions<DefaultValueT> = {
+	/**
+	 * The default value to use
+	 */
+	defaultValue?: DefaultValueT;
+};

--- a/libs/ngxtension/shared/src/options/index.ts
+++ b/libs/ngxtension/shared/src/options/index.ts
@@ -1,0 +1,3 @@
+export * from './default-value';
+export * from './injector';
+export * from './transform';

--- a/libs/ngxtension/shared/src/options/index.ts
+++ b/libs/ngxtension/shared/src/options/index.ts
@@ -1,3 +1,3 @@
 export * from './default-value';
 export * from './injector';
-export * from './transform';
+export * from './parse';

--- a/libs/ngxtension/shared/src/options/injector.ts
+++ b/libs/ngxtension/shared/src/options/injector.ts
@@ -1,0 +1,8 @@
+/**
+ * The optional "custom" Injector. If this is not provided, will be retrieved from the current injection context
+ */
+import type { Injector } from '@angular/core';
+
+export type InjectorOptions = {
+	injector?: Injector;
+};

--- a/libs/ngxtension/shared/src/options/parse.ts
+++ b/libs/ngxtension/shared/src/options/parse.ts
@@ -1,0 +1,9 @@
+export type ParseOptions<ReadT, WriteT> = {
+	/**
+	 * A function to convert the written value to the expected read value.
+	 *
+	 * @param v - The value to parse.
+	 * @returns The parsed value.
+	 */
+	parse?: (v: WriteT) => ReadT;
+};

--- a/libs/ngxtension/shared/src/options/transform.ts
+++ b/libs/ngxtension/shared/src/options/transform.ts
@@ -1,0 +1,9 @@
+export type TransformOptions<ReadT, WriteT> = {
+	/**
+	 * A transformation function to convert the written value to the expected read value.
+	 *
+	 * @param v - The value to transform.
+	 * @returns The transformed value.
+	 */
+	transform?: (v: WriteT) => ReadT;
+};

--- a/libs/ngxtension/shared/src/options/transform.ts
+++ b/libs/ngxtension/shared/src/options/transform.ts
@@ -1,9 +1,0 @@
-export type TransformOptions<ReadT, WriteT> = {
-	/**
-	 * A transformation function to convert the written value to the expected read value.
-	 *
-	 * @param v - The value to transform.
-	 * @returns The transformed value.
-	 */
-	transform?: (v: WriteT) => ReadT;
-};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -137,6 +137,7 @@
 			"ngxtension/signal-history": [
 				"libs/ngxtension/signal-history/src/index.ts"
 			],
+			"ngxtension/shared": ["libs/ngxtension/shared/src/index.ts"],
 			"ngxtension/signal-slice": ["libs/ngxtension/signal-slice/src/index.ts"],
 			"ngxtension/singleton-proxy": [
 				"libs/ngxtension/singleton-proxy/src/index.ts"


### PR DESCRIPTION
Adds the following options to all utilities and therefore aligns them.

- injectParams
	- transform
	- defaultValue
	- injector
- injectQueryParams
	- defaultValue
	- injector
- injectQueryParams.array
	- defaultValue
	- injector
- injectRouteData
	- defaultValue
	- injector
- injectRouteFragment
	- defaultValue

I also took the chance to rename `initialValue` to `defaultValue` (as I think it's a more fitting name).
`injectQueryParams` supports both values, as to not introduce a breaking change.