### PR TITLE
fix: remove duplicate test in signal slice spec

### DIFF
--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -138,11 +138,6 @@ describe(signalSlice.name, () => {
 			state.age();
 			expect(testFn).toHaveBeenCalled();
 		});
-
-		it('should connect lazy source after signal value is accessed', () => {
-			state().age;
-			expect(testFn).toHaveBeenCalled();
-		});
 	});
 
 	describe('actionSources', () => {


### PR DESCRIPTION
The only thing different is the description.  