### PR TITLE
fix(plugin): support outputs without inline initialization

### DIFF
--- a/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
+++ b/libs/plugin/src/generators/convert-outputs/__snapshots__/generator.spec.ts.snap
@@ -28,6 +28,13 @@ export class MyCmp {
 
   withObservable = outputFromObservable(this.someObservable$);
   aliasOutput = output<string>({ alias: 'withAlias' });
+  
+  noInitializer = output<string>();
+  
+  initializedInConstructor = output<string>();
+  
+  constructor() {
+  }
 
   ngOnInit() {
     let imABoolean = false;

--- a/libs/plugin/src/generators/convert-outputs/generator.spec.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.spec.ts
@@ -55,6 +55,14 @@ export class MyCmp {
 
   @Output() withObservable = this.someObservable$;
   @Output('withAlias') aliasOutput = new EventEmitter<string>();
+  
+  @Output() noInitializer: EventEmitter<string>;
+  
+  @Output() initializedInConstructor;
+  
+  constructor() {
+    this.initializedInConstructor = new EventEmitter<string>();
+  }
 
   ngOnInit() {
     let imABoolean = false;

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -260,15 +260,9 @@ export async function convertOutputsGenerator(
 				if (Node.isPropertyDeclaration(node)) {
 					const outputDecorator = node.getDecorator('Output');
 					if (outputDecorator) {
-						let {
-							name,
-							isReadonly,
-							docs,
-							scope,
-							type,
-							hasOverrideKeyword,
-							initializer,
-						} = node.getStructure();
+						const { name, isReadonly, docs, scope, type, hasOverrideKeyword } =
+							node.getStructure();
+						let { initializer } = node.getStructure();
 
 						if (!initializer) {
 							// look for constructor initializer

--- a/libs/plugin/src/generators/convert-outputs/generator.ts
+++ b/libs/plugin/src/generators/convert-outputs/generator.ts
@@ -62,8 +62,25 @@ function getOutputInitializer(
 		alias = decoratorArg.getText();
 	}
 
+	const initializerOrType =
+		initializer ?? (typeof currentType === 'string' ? currentType : undefined);
+
+	if (!initializerOrType) {
+		logger.error(
+			`[ngxtension] Unable to find initializer or type for "${propertyName}"`,
+		);
+		return exit(1);
+	}
+
 	// check if the initializer is not an EventEmitter -> means its an observable
-	if (!initializer.includes('EventEmitter')) {
+	if (!initializerOrType.includes('EventEmitter')) {
+		if (!initializer) {
+			logger.error(
+				`[ngxtension] Unable to find initializer for "${propertyName}"`,
+			);
+			return exit(1);
+		}
+
 		// if the initializer is a Subject or BehaviorSubject
 		if (
 			initializer.includes('Subject') ||
@@ -96,10 +113,11 @@ function getOutputInitializer(
 		}
 	} else {
 		let type = '';
-		if (initializer.includes('EventEmitter()')) {
+		if (initializerOrType.includes('EventEmitter()')) {
 			// there is no type
 		} else {
-			const genericTypeOnEmitter = initializer.match(/EventEmitter<(.+)>/);
+			const genericTypeOnEmitter =
+				initializerOrType.match(/EventEmitter<(.+)>/);
 			if (genericTypeOnEmitter?.length) {
 				type = genericTypeOnEmitter[1];
 			}
@@ -242,7 +260,7 @@ export async function convertOutputsGenerator(
 				if (Node.isPropertyDeclaration(node)) {
 					const outputDecorator = node.getDecorator('Output');
 					if (outputDecorator) {
-						const {
+						let {
 							name,
 							isReadonly,
 							docs,
@@ -251,6 +269,20 @@ export async function convertOutputsGenerator(
 							hasOverrideKeyword,
 							initializer,
 						} = node.getStructure();
+
+						if (!initializer) {
+							// look for constructor initializer
+							const constructor = targetClass.getConstructors()[0];
+							if (constructor) {
+								const constructorInitializer = constructor
+									.getStatements()
+									.find((stmt) => stmt.getText().includes(`${name} =`));
+								if (constructorInitializer) {
+									initializer = constructorInitializer.getText();
+								}
+								constructorInitializer?.remove();
+							}
+						}
 
 						const {
 							needsOutputFromObservableImport,


### PR DESCRIPTION
Previously, this script would fail with a cryptic message (`cannot read property of undefined (reading includes)`) for input like:
```ts
@Output() myOutput: EventEmitter<string>;
```

The changes support that use case and:
- Uses the initialization in the constructor to infer the type (and removes it)
- Creates an initialization (`= output()`) if it doesn't exist