### PR TITLE
refactor: Handle getting value from disabled form controls in `form-events` util

### DIFF
--- a/libs/ngxtension/form-events/src/form-events.spec.ts
+++ b/libs/ngxtension/form-events/src/form-events.spec.ts
@@ -115,7 +115,7 @@ describe('Form Events', () => {
 		);
 	});
 
-	it('returns a signal with the value, status, pristine, and touched values of a form after it has been interacted with', async () => {
+	it('returns an observable with the value, status, pristine, and touched values of a form after it has been interacted with', async () => {
 		const fixture: ComponentFixture<FormEventsComponent> =
 			TestBed.configureTestingModule({
 				imports: [FormEventsComponent],
@@ -165,8 +165,28 @@ describe('Form Events', () => {
 
 		fixture.detectChanges();
 
-		const signalVals: HTMLElement = fixture.debugElement.query(
+		const observableVals: HTMLElement = fixture.debugElement.query(
 			By.css('[data-testid="observable-values-initial-value-overwritten"]'),
+		).nativeElement;
+
+		expect(flattenJsonPipeFormatting(observableVals.textContent)).toBe(
+			flattenJsonPipeFormatting(`{
+            "value": {
+                "name": "custom"
+            },
+            "status": "VALID",
+            "touched": false,
+            "pristine": true,
+            "valid": true,
+            "invalid": false,
+            "pending": false,
+            "dirty": false,
+            "untouched": true
+            }`),
+		);
+
+		const signalVals: HTMLElement = fixture.debugElement.query(
+			By.css('[data-testid="signal-values-initial-value-overwritten"]'),
 		).nativeElement;
 
 		expect(flattenJsonPipeFormatting(signalVals.textContent)).toBe(

--- a/libs/ngxtension/form-events/src/form-events.spec.ts
+++ b/libs/ngxtension/form-events/src/form-events.spec.ts
@@ -205,6 +205,63 @@ describe('Form Events', () => {
             }`),
 		);
 	});
+
+	it('returns a value of controls or the whole form even if they are disabled', async () => {
+		const fixture: ComponentFixture<FormEventsComponent> =
+			TestBed.configureTestingModule({
+				imports: [FormEventsComponent],
+			}).createComponent(FormEventsComponent);
+
+		fixture.detectChanges();
+
+		const observableVals: HTMLElement = fixture.debugElement.query(
+			By.css('[data-testid="observable-values-disabled"]'),
+		).nativeElement;
+		const signalVals: HTMLElement = fixture.debugElement.query(
+			By.css('[data-testid="signal-values-disabled"]'),
+		).nativeElement;
+
+		const formDisabledButton: HTMLInputElement =
+			fixture.debugElement.nativeElement.querySelector('#formDisable');
+		const formEnabledButton: HTMLInputElement =
+			fixture.debugElement.nativeElement.querySelector('#formEnable');
+		const controlDisabledButton: HTMLInputElement =
+			fixture.debugElement.nativeElement.querySelector('#controlDisable');
+
+		const formValue = `{
+            "value": {
+                "name": ""
+            },
+            "status": "DISABLED",
+            "touched": false,
+            "pristine": true,
+            "valid": false,
+            "invalid": false,
+            "pending": false,
+            "dirty": false,
+            "untouched": true
+            }`;
+
+		formDisabledButton.click();
+		fixture.detectChanges();
+
+		expect(flattenJsonPipeFormatting(observableVals.textContent)).toBe(
+			flattenJsonPipeFormatting(formValue),
+		);
+		expect(flattenJsonPipeFormatting(signalVals.textContent)).toBe(
+			flattenJsonPipeFormatting(formValue),
+		);
+
+		formEnabledButton.click();
+		controlDisabledButton.click();
+		fixture.detectChanges();
+		expect(flattenJsonPipeFormatting(observableVals.textContent)).toBe(
+			flattenJsonPipeFormatting(formValue),
+		);
+		expect(flattenJsonPipeFormatting(signalVals.textContent)).toBe(
+			flattenJsonPipeFormatting(formValue),
+		);
+	});
 });
 
 @Component({
@@ -242,11 +299,34 @@ describe('Form Events', () => {
 			<input data-testid="name" formControlName="name" name="name" />
 		</form>
 
+		<button (click)="setFormDisabledState('formDisable')" id="formDisable">
+			Disable formDisabled
+		</button>
+		<button (click)="setFormDisabledState('formEnable')" id="formEnable">
+			Enable formDisabled
+		</button>
+		<button
+			(click)="setFormDisabledState('controlDisable')"
+			id="controlDisable"
+		>
+			Disable formDisabled's control
+		</button>
+
 		<pre data-testid="signal-values-initial-value-overwritten">{{
 			$formInitialValuesOverwritten() | json
 		}}</pre>
 		<pre data-testid="observable-values-initial-value-overwritten">{{
 			formInitialValuesOverwritten$ | async | json
+		}}</pre>
+
+		<form [formGroup]="formDisabled" id="test-form-disabled">
+			<label for="firstName">Name</label>
+			<input data-testid="name" formControlName="name" name="name" />
+		</form>
+
+		<pre data-testid="signal-values-disabled">{{ $formDisabled() | json }}</pre>
+		<pre data-testid="observable-values-disabled">{{
+			formDisabled$ | async | json
 		}}</pre>
 	`,
 })
@@ -260,6 +340,9 @@ export default class FormEventsComponent implements OnInit {
 	formInitialValueOverwritten = this.fb.group({
 		name: this.fb.control(''),
 	});
+	formDisabled = this.fb.group({
+		name: this.fb.control(''),
+	});
 
 	form$ = allEventsObservable(this.form);
 	$form = allEventsSignal(this.form);
@@ -271,7 +354,24 @@ export default class FormEventsComponent implements OnInit {
 		this.formInitialValueOverwritten,
 	);
 
+	formDisabled$ = allEventsObservable(this.formDisabled);
+	$formDisabled = allEventsSignal(this.formDisabled);
+
 	ngOnInit() {
 		this.formInitialValueOverwritten.controls.name.setValue('custom');
+	}
+
+	setFormDisabledState(type: 'formDisable' | 'formEnable' | 'controlDisable') {
+		switch (type) {
+			case 'formDisable':
+				this.formDisabled.disable();
+				break;
+			case 'formEnable':
+				this.formDisabled.enable();
+				break;
+			case 'controlDisable':
+				this.formDisabled.controls.name.disable();
+				break;
+		}
 	}
 }

--- a/libs/ngxtension/form-events/src/form-events.ts
+++ b/libs/ngxtension/form-events/src/form-events.ts
@@ -161,7 +161,7 @@ export function allEventsSignal<T>(
 ): Signal<FormEventData<T>> {
 	return toSignal(allEventsObservable(form), {
 		initialValue: {
-			value: form.value,
+			value: form.getRawValue(),
 			status: form.status,
 			pristine: form.pristine,
 			touched: form.touched,

--- a/libs/ngxtension/form-events/src/form-events.ts
+++ b/libs/ngxtension/form-events/src/form-events.ts
@@ -99,8 +99,8 @@ export function allEventsObservable<T>(
 	return defer(() =>
 		combineLatest([
 			valueEvents$(form).pipe(
-				startWith(form.value),
-				map((value) => (isValueEvent(value) ? value.value : value)),
+				startWith(form.getRawValue()),
+				map(() => form.getRawValue()),
 				distinctUntilChanged(
 					(previous, current) =>
 						JSON.stringify(previous) === JSON.stringify(current),


### PR DESCRIPTION
## About

In all my efforts to get this util all together, I overlooked one of the most important things when it comes to getting form values from reactive forms (for what I argue in the issue is what most people want): getting the value of the form and each control even if the form is disabled.

Closes #491: "Handle getting value from disabled form controls in `form-events` util"

## Notes
- naming of `form-events` and its functions is outstanding.
- Two existing tests were misphrased and one was not accounting for both of the utils. I threw in changes to those since I was in the test suite anyways.
- @eneajaho about our conversation on naming the signal util: thoughts on `toFormState`? I feel like it is the compliment to the proposed observable util name of `fromFormEvents`. 