### PR TITLE
docs(inject-local-storage): Content entry frontmatter does not match schema

### DIFF
--- a/docs/src/content/docs/utilities/Injectors/inject-local-storage.md
+++ b/docs/src/content/docs/utilities/Injectors/inject-local-storage.md
@@ -1,3 +1,11 @@
+---
+title: injectLocalStorage
+description: ngxtension/inject-local-storage
+entryPoint: ngxtension/inject-local-storage
+badge: stable
+contributors: ['enea-jahollari']
+---
+
 This injector provides a reactive local storage management system using Angular's dependency injection and reactivity model. This API allows for easy integration and manipulation of local storage with real-time synchronization across browser tabs.
 
 ## API


### PR DESCRIPTION
Docs build fails on `docs → utilities/Injectors/inject-local-storage.md frontmatter does not match collection schema.`

```
InvalidContentEntryFrontmatterError: **docs → utilities/Injectors/inject-local-storage.md** frontmatter does not match collection schema.
**title**: Required
    at getEntryData (file:///Users/jmeinlschmidt/projects/ngxtension-platform/docs/node_modules/.pnpm/astro@4.7.0/node_modules/astro/dist/content/utils.js:86:26)
    at async getContentEntryModule (file:///Users/jmeinlschmidt/projects/ngxtension-platform/docs/node_modules/.pnpm/astro@4.7.0/node_modules/astro/dist/content/vite-plugin-content-imports.js:164:35)
    at async TransformContext.transform (file:///Users/jmeinlschmidt/projects/ngxtension-platform/docs/node_modules/.pnpm/astro@4.7.0/node_modules/astro/dist/content/vite-plugin-content-imports.js:79:67)
    at async Object.transform (file:///Users/jmeinlschmidt/projects/ngxtension-platform/docs/node_modules/.pnpm/vite@5.2.10/node_modules/vite/dist/node/chunks/dep-DkOS1hkm.js:51133:30)
    at async loadAndTransform (file:///Users/jmeinlschmidt/projects/ngxtension-platform/docs/node_modules/.pnpm/vite@5.2.10/node_modules/vite/dist/node/chunks/dep-DkOS1hkm.js:53888:29)
    at async instantiateModule (file:///Users/jmeinlschmidt/projects/ngxtension-platform/docs/node_modules/.pnpm/vite@5.2.10/node_modules/vite/dist/node/chunks/dep-DkOS1hkm.js:54932:10)
```

Probably caused by https://github.com/ngxtension/ngxtension-platform/pull/478 (cc @eneajaho)