### PR TITLE
docs: Migrate links to angular.dev

### DIFF
--- a/docs/src/content/docs/es/getting-started/introduction.md
+++ b/docs/src/content/docs/es/getting-started/introduction.md
@@ -5,13 +5,13 @@ sidebar:
   order: 1
 ---
 
-`ngxtension` es una librería de utilidades para [Angular](https://angular.io). Consiste en una variedad de utilidades que facilitan el desarrollo de Angular y lo hacen más consistente.
+`ngxtension` es una librería de utilidades para [Angular](https://angular.dev). Consiste en una variedad de utilidades que facilitan el desarrollo de Angular y lo hacen más consistente.
 
 El proyecto fue iniciado por [Chau](https://github.com/nartc) junto con [Enea](https://twitter.com/Enea_Jahollari) y es completamente [de código abierto](https://github.com/nartc/ngxtension-platform). Agradecemos las contribuciones de todo tipo. Si tienes un problema o una idea, por favor [háznoslo saber](https://github.com/nartc/ngxtension-platform/issues/new).
 ¿Te encuentras agregando algo una y otra vez a cada proyecto de Angular? Eso es algo que queremos tener en `ngxtension`. Nuestra intención es que `ngxtension` sea "_todo vale_", pero también con consideración cuidadosa y código Angular de calidad para que `ngxtension` pueda convertirse en una tienda única para todos los desarrolladores de Angular.
 
 ## Consideración del tamaño del paquete(bundle)
 
-La biblioteca está compuesta enteramente por [Secondary Entry Point](https://angular.io/guide/angular-package-format#entrypoints-and-code-splitting). Aunque enviamos `ngxtension` como un solo paquete (para que sea fácil de instalar para los consumidores), el pipeline de construcción de Angular debe manejar adecuadamente la división de código y el tree-shaking para todos los puntos de entrada que `ngxtension` incluye.
+La biblioteca está compuesta enteramente por [Secondary Entry Point](https://angular.dev/tools/libraries/angular-package-format#entrypoints-and-code-splitting). Aunque enviamos `ngxtension` como un solo paquete (para que sea fácil de instalar para los consumidores), el pipeline de construcción de Angular debe manejar adecuadamente la división de código y el tree-shaking para todos los puntos de entrada que `ngxtension` incluye.
 
 El distintivo de tamaño GZIP (si está disponible) es proporcionado por [bundlejs](https://bundlejs.dev/) y se muestra como el tamaño empaquetado del punto de entrada y todas sus dependencias `ngxtension`. Por ejemplo, `ngxtension/connect` depende de `ngxtension/assert-injector` por lo que el distintivo de tamaño GZIP de `ngxtension/connect` será el tamaño empaquetado de `ngxtension/connect` y `ngxtension/assert-injector`.

--- a/docs/src/content/docs/es/utilities/Assets/svg-sprites.md
+++ b/docs/src/content/docs/es/utilities/Assets/svg-sprites.md
@@ -32,7 +32,7 @@ Sin `NgxSvgSpriteFragment`:
 
 ### Con la API de Composición de Directivas
 
-En tu proyecto, puedes utilizar la [API de Composición de Directivas](https://angular.io/guide/directive-composition-api) para crear sprites de svg específicos.
+En tu proyecto, puedes utilizar la [API de Composición de Directivas](https://angular.dev/guide/directives/directive-composition-api) para crear sprites de svg específicos.
 
 En este ejemplo, se crea un sprite svg de las _marcas de fontawesome_.
 

--- a/docs/src/content/docs/es/utilities/Directives/repeat.md
+++ b/docs/src/content/docs/es/utilities/Directives/repeat.md
@@ -16,7 +16,7 @@ import { Repeat } from 'ngxtension/repeat';
 
 ### Básico
 
-Utiliza la directiva `Repeat` como una extensión de `NgFor` de Angular para iterar sobre un número fijo de iteraciones. La [`TrackByFunction`](https://angular.io/api/core/TrackByFunction) se establece automáticamente para iterar de manera eficiente.
+Utiliza la directiva `Repeat` como una extensión de `NgFor` de Angular para iterar sobre un número fijo de iteraciones. La [`TrackByFunction`](https://angular.dev/api/core/TrackByFunction) se establece automáticamente para iterar de manera eficiente.
 
 ```ts
 import { Component } from '@angular/core';

--- a/docs/src/content/docs/es/utilities/Directives/resize.mdx
+++ b/docs/src/content/docs/es/utilities/Directives/resize.mdx
@@ -19,7 +19,7 @@ El `resize` entry point expone 2 symbols:
 - `injectResize()`: un CIF que observa el evento de cambio de tamaño en el elemento Host del componente.
 - `NgxResize`: una directiva que puede observar el evento de cambio de tamaño de cualquier elemento al que esté adjunta.
 
-Ambos emiten el resultado del cambio de tamaño fuera de la [Zona Angular](https://angular.io/guide/zone) de forma predeterminada, pero ambos proporcionan una forma de configurar el comportamiento.
+Ambos emiten el resultado del cambio de tamaño fuera de la [Zona Angular](https://angular.dev/best-practices/zone-pollution) de forma predeterminada, pero ambos proporcionan una forma de configurar el comportamiento.
 
 ## Uso
 

--- a/docs/src/content/docs/es/utilities/Forms/control-value-accessor.md
+++ b/docs/src/content/docs/es/utilities/Forms/control-value-accessor.md
@@ -6,7 +6,7 @@ badge: stable
 contributors: ['robby-rabbitman']
 ---
 
-`NgxControlValueAccessor` es una directiva para reducir la redundancia al construir componentes que implementan la interfaz [ControlValueAccessor](https://angular.io/api/forms/ControlValueAccessor).
+`NgxControlValueAccessor` es una directiva para reducir la redundancia al construir componentes que implementan la interfaz [ControlValueAccessor](https://angular.dev/api/forms/ControlValueAccessor).
 
 ## Importar
 
@@ -16,7 +16,7 @@ import { NgxControlValueAccessor } from 'ngxtension/control-value-accessor';
 
 ## Uso
 
-`NgxControlValueAccessor` implementa la interfaz [ControlValueAccessor](https://angular.io/api/forms/ControlValueAccessor) y expone una api _más simple_. Declara `NgxControlValueAccessor` en la sección `hostDirectives` de tu componente e inyecta la instancia para conectar tu plantilla:
+`NgxControlValueAccessor` implementa la interfaz [ControlValueAccessor](https://angular.dev/api/forms/ControlValueAccessor) y expone una api _más simple_. Declara `NgxControlValueAccessor` en la sección `hostDirectives` de tu componente e inyecta la instancia para conectar tu plantilla:
 
 - `NgxControlValueAccessor.value` para sincronizar el valor.
 - `NgxControlValueAccessor.disabled` para sincronizar el estado deshabilitado.

--- a/docs/src/content/docs/es/utilities/Injectors/assert-injector.md
+++ b/docs/src/content/docs/es/utilities/Injectors/assert-injector.md
@@ -6,9 +6,9 @@ entryPoint: assert-injector
 contributors: ['chau-tran']
 ---
 
-`assertInjector` es una extensión de [`assertInInjectionContext`](https://angular.io/api/core/assertInInjectionContext) que acepta una `Function` y un `Injector` personalizado opcional.
+`assertInjector` es una extensión de [`assertInInjectionContext`](https://angular.dev/api/core/assertInInjectionContext) que acepta una `Function` y un `Injector` personalizado opcional.
 
-`assertInjector` afirmará que la `Function` se invoque en un [Contexto de Inyección](https://angular.io/guide/dependency-injection-context) y devolverá un `Injector` **garantizado** ya sea el _personalizado_ que se pasa o el _predeterminado_.
+`assertInjector` afirmará que la `Function` se invoque en un [Contexto de Inyección](https://angular.dev/guide/di/dependency-injection-context) y devolverá un `Injector` **garantizado** ya sea el _personalizado_ que se pasa o el _predeterminado_.
 
 ```ts
 import { assertInjector } from 'ngxtension/assert-injector';

--- a/docs/src/content/docs/es/utilities/Injectors/create-injection-token.md
+++ b/docs/src/content/docs/es/utilities/Injectors/create-injection-token.md
@@ -6,7 +6,7 @@ entryPoint: create-injection-token
 contributors: ['chau-tran']
 ---
 
-`createInjectionToken` es una abstacción sobre la creación de un [`InjectionToken`](https://angular.io/api/core/InjectionToken) y devuelve una tupla de `[injectFn, provideFn, TOKEN]`
+`createInjectionToken` es una abstacción sobre la creación de un [`InjectionToken`](https://angular.dev/api/core/InjectionToken) y devuelve una tupla de `[injectFn, provideFn, TOKEN]`
 
 Crear un `InjectionToken` no suele ser un gran problema, pero consumir el `InjectionToken` puede ser un poco tedioso si el proyecto utiliza `InjectionToken` mucho.
 

--- a/docs/src/content/docs/es/utilities/Intl/intl.md
+++ b/docs/src/content/docs/es/utilities/Intl/intl.md
@@ -10,7 +10,7 @@ Esto es una colección de pipes diseñados para aplicaciones Angular que aprovec
 
 Aunque no está pensado para reemplazar completamente los pipes estándar de Angular para `currency`, `date` y `number`, sirve como un kit de herramientas complementario para mejorar las funcionalidades existentes.
 
-El locale por defecto se determina mediante el token [`LOCALE_ID`](https://angular.io/api/core/LOCALE_ID). Al alterar esto se cambiará el locale para todos los pipes incluidos.
+El locale por defecto se determina mediante el token [`LOCALE_ID`](https://angular.dev/api/core/LOCALE_ID). Al alterar esto se cambiará el locale para todos los pipes incluidos.
 
 Como alternativa, puedes especificar el locale directamente como **último parámetro de cualquier pipe, anulando así la configuración por defecto**.
 

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -5,13 +5,13 @@ sidebar:
   order: 1
 ---
 
-`ngxtension` is a utilities library for [Angular](https://angular.io). It consists of a variety of utilities that make Angular development easier and more consistent.
+`ngxtension` is a utilities library for [Angular](https://angular.dev). It consists of a variety of utilities that make Angular development easier and more consistent.
 
 The project is kick-started by [Chau](https://github.com/nartc) along with [Enea](https://twitter.com/Enea_Jahollari) and it is fully [open-sourced](https://github.com/nartc/ngxtension-platform). We welcome contributions of all kinds. If you have an issue or idea, please [let us know](https://github.com/nartc/ngxtension-platform/issues/new)
 Find yourself adding something over and over again to every Angular projects? That is something we want to have in `ngxtension`. We intend for `ngxtension` to be "_anything goes_" but with careful consideration as well as up-to-standard Angular code so that `ngxtension` can become a one-stop shop for every Angular developer out there.
 
 ## Bundle-size Consideration
 
-The library is entirely consisted of [Secondary Entry Point](https://angular.io/guide/angular-package-format#entrypoints-and-code-splitting). Even though we ship `ngxtension` as one package (so it is easy for consumers to install), Angular build pipeline should handle code-splitting and tree-shaking properly for all the entry points that `ngxtension` comes with.
+The library is entirely consisted of [Secondary Entry Point](https://angular.dev/tools/libraries/angular-package-format#entrypoints-and-code-splitting). Even though we ship `ngxtension` as one package (so it is easy for consumers to install), Angular build pipeline should handle code-splitting and tree-shaking properly for all the entry points that `ngxtension` comes with.
 
 The GZIP size badge (if available) is provided by [bundlejs](https://bundlejs.com/) and it is shown as the bundled size of the entry point and all of its `ngxtension` dependencies. For example, `ngxtension/connect` depends on `ngxtension/assert-injector` so the GZIP size badge of `ngxtension/connect` will be the bundled size of `ngxtension/connect` and `ngxtension/assert-injector`.

--- a/docs/src/content/docs/utilities/Assets/svg-sprites.md
+++ b/docs/src/content/docs/utilities/Assets/svg-sprites.md
@@ -32,7 +32,7 @@ Without `NgxSvgSpriteFragment`:
 
 ### With Directive Composition Api
 
-In your project you can utilize the [Directive Composition Api](https://angular.io/guide/directive-composition-api) to create specific svg sprites.
+In your project you can utilize the [Directive Composition Api](https://angular.dev/guide/directives/directive-composition-api) to create specific svg sprites.
 
 In this example a _fontawesome brands_ svg sprite is created.
 

--- a/docs/src/content/docs/utilities/Directives/repeat.mdx
+++ b/docs/src/content/docs/utilities/Directives/repeat.mdx
@@ -43,7 +43,7 @@ This will produce the same output as the directive variant.
 
 ### Basic
 
-Use the `Repeat` directive as an extension of Angular's `NgFor` to iterate over a fixed number of iterations. The [`TrackByFunction`](https://angular.io/api/core/TrackByFunction) is automatically set to efficiently iterate.
+Use the `Repeat` directive as an extension of Angular's `NgFor` to iterate over a fixed number of iterations. The [`TrackByFunction`](https://angular.dev/api/core/TrackByFunction) is automatically set to efficiently iterate.
 
 ```ts
 import { Component } from '@angular/core';

--- a/docs/src/content/docs/utilities/Directives/resize.mdx
+++ b/docs/src/content/docs/utilities/Directives/resize.mdx
@@ -19,7 +19,7 @@ import { NgxResize, injectResize } from 'ngxtension/resize';
 - `injectResize()`: a CIF that observes the resize event on the Host element of the component
 - `NgxResize`: a directive that can observe the resize event of any element that it is attached on
 
-Both emit resize result outside of [Angular Zone](https://angular.io/guide/zone) by default but both provide way to configure the behavior.
+Both emit resize result outside of [Angular Zone](https://angular.dev/best-practices/zone-pollution) by default but both provide way to configure the behavior.
 
 ## Usage
 

--- a/docs/src/content/docs/utilities/Forms/control-value-accessor.md
+++ b/docs/src/content/docs/utilities/Forms/control-value-accessor.md
@@ -6,7 +6,7 @@ badge: stable
 contributors: ['robby-rabbitman']
 ---
 
-`NgxControlValueAccessor` is a directive to reduce boilerplate when building components, which implement the [ControlValueAccessor](https://angular.io/api/forms/ControlValueAccessor) interface.
+`NgxControlValueAccessor` is a directive to reduce boilerplate when building components, which implement the [ControlValueAccessor](https://angular.dev/api/forms/ControlValueAccessor) interface.
 
 ## Import
 
@@ -16,7 +16,7 @@ import { NgxControlValueAccessor } from 'ngxtension/control-value-accessor';
 
 ## Usage
 
-`NgxControlValueAccessor` implements the [ControlValueAccessor](https://angular.io/api/forms/ControlValueAccessor) interface and exposes a _simpler_ api. Declare `NgxControlValueAccessor` in the `hostDirectives` section of your component and inject the instance in order to wire up your template:
+`NgxControlValueAccessor` implements the [ControlValueAccessor](https://angular.dev/api/forms/ControlValueAccessor) interface and exposes a _simpler_ api. Declare `NgxControlValueAccessor` in the `hostDirectives` section of your component and inject the instance in order to wire up your template:
 
 - `NgxControlValueAccessor.value` for syncing the value
 - `NgxControlValueAccessor.disabled` for syncing the disabled state

--- a/docs/src/content/docs/utilities/Injectors/assert-injector.md
+++ b/docs/src/content/docs/utilities/Injectors/assert-injector.md
@@ -6,9 +6,9 @@ badge: stable
 contributors: ['chau-tran']
 ---
 
-`assertInjector` is an extension of [`assertInInjectionContext`](https://angular.io/api/core/assertInInjectionContext) that accepts a `Function` and an optional custom `Injector`
+`assertInjector` is an extension of [`assertInInjectionContext`](https://angular.dev/api/core/assertInInjectionContext) that accepts a `Function` and an optional custom `Injector`
 
-`assertInjector` will assert that the `Function` is invoked in an [Injection Context](https://angular.io/guide/dependency-injection-context) and will return a **guaranteed** `Injector` whether it is the _custom_ one that is passed in or the _default_ one.
+`assertInjector` will assert that the `Function` is invoked in an [Injection Context](https://angular.dev/guide/di/dependency-injection-context) and will return a **guaranteed** `Injector` whether it is the _custom_ one that is passed in or the _default_ one.
 
 ```ts
 import { assertInjector } from 'ngxtension/assert-injector';

--- a/docs/src/content/docs/utilities/Injectors/create-injection-token.md
+++ b/docs/src/content/docs/utilities/Injectors/create-injection-token.md
@@ -6,7 +6,7 @@ badge: stable
 contributors: ['chau-tran']
 ---
 
-`createInjectionToken` is an abstraction over the creation of an [`InjectionToken`](https://angular.io/api/core/InjectionToken) and returns a tuple of `[injectFn, provideFn, TOKEN]`
+`createInjectionToken` is an abstraction over the creation of an [`InjectionToken`](https://angular.dev/api/core/InjectionToken) and returns a tuple of `[injectFn, provideFn, TOKEN]`
 
 Creating an `InjectionToken` is usually not a big deal but consuming the `InjectionToken` might be a bit of a chore/boilerplate if the project utilizes `InjectionToken` a lot.
 

--- a/docs/src/content/docs/utilities/Intl/intl.md
+++ b/docs/src/content/docs/utilities/Intl/intl.md
@@ -10,7 +10,7 @@ This is a collection of pipes designed for Angular applications that leverage th
 
 While it's not intended to fully replace Angular's standard pipes for `currency`, `date`, and `number`, it serves as a supplemental toolkit to enhance existing functionalities.
 
-The default locale is determined by the [`LOCALE_ID` token](https://angular.io/api/core/LOCALE_ID). Altering this will change the locale for all included pipes.
+The default locale is determined by the [`LOCALE_ID` token](https://angular.dev/api/core/LOCALE_ID). Altering this will change the locale for all included pipes.
 
 Alternatively, you can specify the locale directly as the **final parameter to any pipe, thereby overriding the default setting**.
 

--- a/docs/src/content/docs/utilities/Pipes/repeat.mdx
+++ b/docs/src/content/docs/utilities/Pipes/repeat.mdx
@@ -51,7 +51,7 @@ This will produce the following output:
 The pipe can also be utilized with the `ngFor` directive.
 
 <Aside type="tip">
-The  [`TrackByFunction`](https://angular.io/api/core/TrackByFunction) **is not** automatically set.
+The  [`TrackByFunction`](https://angular.dev/api/core/TrackByFunction) **is not** automatically set.
 Checkout the [Repeat Directive](/utilities/directives/repeat) as an alternative.
 
 ```ts

--- a/libs/ngxtension/README.md
+++ b/libs/ngxtension/README.md
@@ -1,6 +1,6 @@
 # NG Extension Platform
 
-A collection of utilities for [Angular](https://angular.io).
+A collection of utilities for [Angular](https://angular.dev).
 
 ## Installation
 

--- a/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
+++ b/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
@@ -47,11 +47,11 @@ export const provideCvaCompareToByProp = <T>(prop: keyof T) =>
 	provideCvaCompareTo((a, b) => Object.is(a?.[prop], b?.[prop]), true);
 
 /**
- * `NgxControlValueAccessor` is a directive to reduce boilerplate when building components, which implement the [ControlValueAccessor](https://angular.io/api/forms/ControlValueAccessor) interface.
+ * `NgxControlValueAccessor` is a directive to reduce boilerplate when building components, which implement the [ControlValueAccessor](https://angular.dev/api/forms/ControlValueAccessor) interface.
  *
  * ## Usage
  *
- * `NgxControlValueAccessor` implements the [ControlValueAccessor](https://angular.io/api/forms/ControlValueAccessor) interface and exposes a _simpler_ api. Declare `NgxControlValueAccessor` in the `hostDirectives` section of your component and inject the instance in order to wire up your template:
+ * `NgxControlValueAccessor` implements the [ControlValueAccessor](https://angular.dev/api/forms/ControlValueAccessor) interface and exposes a _simpler_ api. Declare `NgxControlValueAccessor` in the `hostDirectives` section of your component and inject the instance in order to wire up your template:
  *
  * - `NgxControlValueAccessor.value` for syncing the value
  * - `NgxControlValueAccessor.disabled` for syncing the disabled state

--- a/libs/ngxtension/svg-sprite/src/svg-sprite.ts
+++ b/libs/ngxtension/svg-sprite/src/svg-sprite.ts
@@ -188,7 +188,7 @@ const createSvgSprite = (options: CreateNgxSvgSpriteOptions) => {
  *
  * ### With Directive Composition Api
  *
- * In your project you can utilize the [Directive Composition Api](https://angular.io/guide/directive-composition-api) to create specific svg sprites.
+ * In your project you can utilize the [Directive Composition Api](https://angular.dev/guide/directives/directive-composition-api) to create specific svg sprites.
  *
  * In this example a _fontawesome brands_ svg sprite is created.
  *


### PR DESCRIPTION
Migrated links `angular.io` to according pages in the new `angular.dev` website