### PR TITLE
fix(docs): fix incorrect derive loading entrypoint

### DIFF
--- a/docs/src/content/docs/utilities/Operators/derive-loading.md
+++ b/docs/src/content/docs/utilities/Operators/derive-loading.md
@@ -1,7 +1,7 @@
 ---
 title: deriveLoading
 description: ngxtension/derive-loading
-entryPoint: derive-loading
+entryPoint: ngxtension/derive-loading
 badge: stable
 contributors: ['michael-berger']
 ---


### PR DESCRIPTION
Corrects `deriveLoading` entryPoint in docs, that wasn't replaced during previous entryPoint migration.