### PR TITLE
fix(signal-slice): add initial state stream typing to state object

### DIFF
--- a/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.spec.ts
@@ -1,3 +1,4 @@
+import { toSignal } from '@angular/core/rxjs-interop';
 import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { Observable, Subject, of, timer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
@@ -31,6 +32,24 @@ describe(signalSlice.name, () => {
 
 		it('should create default selectors', () => {
 			expect(state.age()).toEqual(initialState.age);
+		});
+
+		it('should provide streams of initial state', () => {
+			TestBed.runInInjectionContext(() => {
+				const state = signalSlice({
+					initialState,
+					actionSources: {
+						increaseAge: (state, $: Observable<void>) =>
+							$.pipe(map(() => ({ age: state().age + 1 }))),
+					},
+				});
+
+				const age = toSignal(state.age$);
+
+				state.increaseAge();
+				TestBed.flushEffects();
+				expect(age()).toEqual(initialState.age + 1);
+			});
 		});
 
 		it('should not accept optional properties in initial state', () => {

--- a/libs/ngxtension/signal-slice/src/signal-slice.ts
+++ b/libs/ngxtension/signal-slice/src/signal-slice.ts
@@ -121,6 +121,7 @@ export type SignalSlice<
 	Selectors<TSignalValue> &
 	ExtraSelectors<TSelectors> &
 	Effects<TEffects> &
+	InitialStateStreams<TSignalValue> &
 	ActionMethods<TSignalValue, TActionSources> &
 	ActionStreams<TSignalValue, TActionSources> &
 	ActionUpdates<TSignalValue, TActionSources>;


### PR DESCRIPTION
fixes #520 