### PR TITLE
feat: add migration to convert from ngOnDestroy to DestroyRef

### DIFF
--- a/libs/plugin/generators.json
+++ b/libs/plugin/generators.json
@@ -36,6 +36,11 @@
 			"factory": "./src/generators/convert-to-sfc/generator",
 			"schema": "./src/generators/convert-to-sfc/schema.json",
 			"description": "libs/plugin/src/generators/convert-to-sfc/ generator"
+		},
+		"convert-to-destroy-ref": {
+			"factory": "./src/generators/convert-to-destroy-ref/generator",
+			"schema": "./src/generators/convert-to-destroy-ref/schema.json",
+			"description": "libs/plugin/src/generators/convert-to-destroy-ref/ generator"
 		}
 	},
 	"schematics": {
@@ -80,6 +85,11 @@
 			"factory": "./src/generators/convert-to-sfc/compat",
 			"schema": "./src/generators/convert-to-sfc/schema.json",
 			"description": "libs/plugin/src/generators/convert-to-sfc/ generator"
+		},
+		"convert-to-destroy-ref": {
+			"factory": "./src/generators/convert-to-destroy-ref/compat",
+			"schema": "./src/generators/convert-to-destroy-ref/schema.json",
+			"description": "libs/plugin/src/generators/convert-to-destroy-ref/ generator"
 		}
 	}
 }

--- a/libs/plugin/src/generators/convert-to-destroy-ref/compat.ts
+++ b/libs/plugin/src/generators/convert-to-destroy-ref/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nx/devkit';
+import convertToDestroyRefGenerator from './generator';
+
+export default convertNxGenerator(convertToDestroyRefGenerator);

--- a/libs/plugin/src/generators/convert-to-destroy-ref/generator.ts
+++ b/libs/plugin/src/generators/convert-to-destroy-ref/generator.ts
@@ -1,0 +1,195 @@
+import {
+	formatFiles,
+	getProjects,
+	logger,
+	readProjectConfiguration,
+	Tree,
+} from '@nx/devkit';
+import { exit } from 'node:process';
+import {
+	ClassDeclaration,
+	MethodDeclaration,
+	Project,
+	Scope,
+	SourceFile,
+} from 'ts-morph';
+import { assertDependencyExist } from '../shared-utils/assert-dependency-exist';
+import { assertDependencyVersion } from '../shared-utils/assert-dependency-version';
+import { removeImport } from '../shared-utils/import-utils';
+import { syncNxTreeWithTsMorph } from '../shared-utils/sync-nx-tree-with-ts-morph';
+import { ConvertToDestroyrefSchema } from './schema';
+
+export async function convertToDestroyRefGenerator(
+	tree: Tree,
+	options: ConvertToDestroyrefSchema,
+) {
+	logger.info('[ngxtension] Converting to DestroyRef');
+
+	assertDependencyExist({
+		tree,
+		dependencyName: '@angular/core',
+	});
+	assertDependencyVersion({
+		tree,
+		dependencyName: '@angular/core',
+		featureName: 'DestroyRef',
+		targetVersion: {
+			major: 16,
+			minor: 0,
+		},
+	});
+
+	const predicate = (filePath: string) => {
+		// read content
+		const fileContent = tree.read(filePath, 'utf-8');
+		// check if file content contains ngOnDestroy
+		return fileContent.includes('ngOnDestroy');
+	};
+	const { path, project } = options;
+
+	if (path && project) {
+		logger.error(
+			`[ngxtension] Cannot pass both "path" and "project" to convertToDestroyRefGenerator`,
+		);
+		return exit(1);
+	}
+	const tsMorphProject = new Project({ useInMemoryFileSystem: true });
+
+	if (path && !project) {
+		if (path && !tree.exists(path)) {
+			logger.error(`[ngxtension] "${path}" does not exist`);
+			return exit(1);
+		}
+		syncNxTreeWithTsMorph({
+			project: tsMorphProject,
+			tree,
+			projectRoot: path,
+			predicate,
+		});
+	}
+
+	if (project && !path) {
+		const projectConfiguration = readProjectConfiguration(tree, project);
+
+		if (!projectConfiguration) {
+			logger.error(`"${project}" project not found`);
+			return exit(1);
+		}
+
+		syncNxTreeWithTsMorph({
+			project: tsMorphProject,
+			tree,
+			projectRoot: projectConfiguration.root,
+			predicate,
+		});
+	}
+
+	if (!path && !project) {
+		const projects = getProjects(tree);
+		for (const project of projects.values()) {
+			syncNxTreeWithTsMorph({
+				project: tsMorphProject,
+				tree,
+				projectRoot: project.root,
+				predicate,
+			});
+		}
+	}
+
+	// run the migration for all collected source files
+	const sourceFiles = tsMorphProject.getSourceFiles();
+
+	for (const sourceFile of sourceFiles) {
+		const hasNgOnDestroy = sourceFile
+			.getClasses()
+			.some((classDecl) => classDecl.getMethod('ngOnDestroy'));
+
+		if (!hasNgOnDestroy) continue;
+
+		migrateFile(sourceFile, options.useEsprivateFieldNotation ?? false);
+		await sourceFile.save();
+		tree.write(sourceFile.getFilePath(), sourceFile.getFullText());
+	}
+
+	await formatFiles(tree);
+	logger.info(
+		`
+[ngxtension] Conversion completed. Please check the content and run your formatter as needed.
+`,
+	);
+}
+
+function migrateFile(
+	sourceFile: SourceFile,
+	useEsprivateFieldNotation: boolean,
+) {
+	// Handle imports
+	updateImports(sourceFile);
+
+	// Process each class in the file
+	sourceFile.getClasses().forEach((classDeclaration) => {
+		const ngOnDestroyMethod = classDeclaration.getMethod('ngOnDestroy');
+		if (!ngOnDestroyMethod) return;
+
+		migrateClass(
+			classDeclaration,
+			ngOnDestroyMethod,
+			useEsprivateFieldNotation,
+		);
+	});
+}
+
+function updateImports(sourceFile: SourceFile) {
+	// Remove OnDestroy from imports
+	sourceFile.getImportDeclarations().forEach((importDecl) => {
+		if (importDecl.getModuleSpecifier().getText().includes('@angular/core')) {
+			const namedImports = importDecl.getNamedImports();
+			const onDestroyImport = namedImports.find(
+				(named) => named.getName() === 'OnDestroy',
+			);
+
+			// Add inject and DestroyRef if they don't exist
+			if (!namedImports.some((named) => named.getName() === 'inject')) {
+				importDecl.addNamedImport('inject');
+			}
+			if (!namedImports.some((named) => named.getName() === 'DestroyRef')) {
+				importDecl.addNamedImport('DestroyRef');
+			}
+		}
+	});
+	removeImport('OnDestroy', '@angular/core', sourceFile);
+}
+
+function migrateClass(
+	classDecl: ClassDeclaration,
+	ngOnDestroyMethod: MethodDeclaration,
+	useEsprivateFieldNotation: boolean,
+) {
+	// Remove implements OnDestroy
+	const implementsClause = classDecl.getImplements();
+
+	const implemendsOnDestroyIndex = implementsClause.findIndex(
+		(impl) => impl.getText() === 'OnDestroy',
+	);
+
+	classDecl.removeImplements(implemendsOnDestroyIndex);
+
+	// Extract ngOnDestroy body
+	const ngOnDestroyBody = ngOnDestroyMethod.getBodyText() || '';
+
+	// Create new destroyRef field
+	const properties = classDecl.getProperties();
+	const insertIndex = properties.length > 0 ? properties[0].getChildIndex() : 0;
+
+	classDecl.insertProperty(insertIndex, {
+		name: useEsprivateFieldNotation ? '#destroyRef' : 'destroyRef',
+		initializer: `inject(DestroyRef).onDestroy(() => {${ngOnDestroyBody}})`,
+		scope: useEsprivateFieldNotation ? null : Scope.Private,
+		isReadonly: true,
+	});
+
+	// Remove ngOnDestroy method
+	ngOnDestroyMethod.remove();
+}
+
+export default convertToDestroyRefGenerator;

--- a/libs/plugin/src/generators/convert-to-destroy-ref/schema.d.ts
+++ b/libs/plugin/src/generators/convert-to-destroy-ref/schema.d.ts
@@ -1,0 +1,6 @@
+export interface ConvertToDestroyrefSchema {
+	project?: string;
+	path?: string;
+	includeReadonlyByDefault?: boolean;
+	useEsprivateFieldNotation?: boolean;
+}

--- a/libs/plugin/src/generators/convert-to-destroy-ref/schema.json
+++ b/libs/plugin/src/generators/convert-to-destroy-ref/schema.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://json-schema.org/schema",
+	"$id": "convertoDestroyref",
+	"title": "",
+	"type": "object",
+	"properties": {
+		"project": {
+			"type": "string",
+			"aliases": ["name", "projectName"],
+			"description": "Project for which to convert from constructor DI to inject function."
+		},
+		"path": {
+			"type": "string",
+			"description": "Path to the component/directive/pipe you want to convert to use the inject function"
+		},
+		"useEsprivateFieldNotation": {
+			"type": "boolean",
+			"aliases": [
+				"useESPrivateFieldNotation",
+				"useEsprivateFieldNotation",
+				"useEsPrivateFieldNotation"
+			],
+			"description": "Whether to replace TS private modifier with ES private field notation. Default is false."
+		}
+	}
+}

--- a/libs/plugin/src/generators/shared-utils/assert-dependency-exist.ts
+++ b/libs/plugin/src/generators/shared-utils/assert-dependency-exist.ts
@@ -1,0 +1,19 @@
+import { logger, readJson, Tree } from '@nx/devkit';
+import { exit } from 'node:process';
+
+export function assertDependencyExist(options: {
+	tree: Tree;
+	dependencyName: string;
+	dependencyType?: 'dependencies' | 'devDependencies';
+}) {
+	const packageJson = readJson(options.tree, 'package.json');
+	const dependency =
+		packageJson[options.dependencyType ?? 'dependencies'][
+			options.dependencyName
+		];
+
+	if (!dependency) {
+		logger.error(`[ngxtension] No ${options.dependencyName} detected`);
+		return exit(1);
+	}
+}

--- a/libs/plugin/src/generators/shared-utils/assert-dependency-version.ts
+++ b/libs/plugin/src/generators/shared-utils/assert-dependency-version.ts
@@ -1,0 +1,38 @@
+import { logger, readJson, Tree } from '@nx/devkit';
+import { exit } from 'node:process';
+
+export function assertDependencyVersion(options: {
+	tree: Tree;
+	dependencyName: string;
+	dependencyType?: 'dependencies' | 'devDependencies';
+	targetVersion: {
+		major: number;
+		minor: number;
+	};
+	featureName: string;
+}) {
+	const packageJson = readJson(options.tree, 'package.json');
+	const dependency =
+		packageJson[options.dependencyType ?? 'dependencies'][
+			options.dependencyName
+		];
+
+	const [major, minor] = dependency
+		.split('.')
+		.slice(0, 2)
+		.map((part: string) => {
+			if (part.startsWith('^') || part.startsWith('~')) {
+				return Number(part.slice(1));
+			}
+			return Number(part);
+		});
+
+	if (
+		[major, minor] < [options.targetVersion.major, options.targetVersion.minor]
+	) {
+		logger.error(
+			`[ngxtension] ${options.featureName} is only available in v${options.targetVersion.major}.${options.targetVersion.minor} and later`,
+		);
+		return exit(1);
+	}
+}

--- a/libs/plugin/src/generators/shared-utils/sync-nx-tree-with-ts-morph.ts
+++ b/libs/plugin/src/generators/shared-utils/sync-nx-tree-with-ts-morph.ts
@@ -1,0 +1,23 @@
+import { Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import { Project } from 'ts-morph';
+
+export function syncNxTreeWithTsMorph(options: {
+	project: Project;
+	tree: Tree;
+	projectRoot: string;
+	predicate?: (filePath: string) => boolean;
+}) {
+	visitNotIgnoredFiles(options.tree, options.projectRoot, (filePath) => {
+		if (filePath.endsWith('.ts')) {
+			if (options.predicate && !options.predicate(filePath)) {
+				return;
+			}
+			const fileContent = options.tree.read(filePath, 'utf-8');
+			if (fileContent) {
+				options.project.createSourceFile(filePath, fileContent, {
+					overwrite: true,
+				});
+			}
+		}
+	});
+}


### PR DESCRIPTION
# DRAFT

Draft for a migration schematic to migrate from `ngOnDestroy` lifecycle hook to `DestroyRef`.

Please bare with me - I have not written many schematics for now :) 

## todos

- [ ] tests
- [ ] docs


## Feedback wanted
I would like to know if you generally like the idea. 

Also I would like to know which style you would prefer:

```ts
// option 1 (currently implemented this way in the schematic)
export class SomeComponent {
  readonly #destroy = inject(DestroyRef).onDestroy(() => {
    // whatever was before in ngOnDestroy
  });
}

// option 2 
export class SomeComponent {
  readonly #destroyRef = inject(DestroyRef)
  
  constructor(){
   this.#destroyRef.onDestroy(() => {
    // whatever was before in ngOnDestroy
  });
}

}
```

Anything else I should consider? 
