### PR TITLE
fix(docs): fix typo in retryOnError field

### DIFF
--- a/docs/src/content/docs/utilities/Stores/create-effect.md
+++ b/docs/src/content/docs/utilities/Stores/create-effect.md
@@ -83,13 +83,13 @@ export class Example {
 	// Will not resubscribe on error
 	private loadProducts = createEffect<string>(
 		(_) => _.pipe(switchMap((id) => this.api.loadProducts(id))),
-		{ retryOnEror: false },
+		{ retryOnError: false },
 	);
 
 	// Will resubscribe on error with a delay, not more than 3 times
 	private loadProducts = createEffect<string>(
 		(_) => _.pipe(switchMap((id) => this.api.loadProducts(id))),
-		{ retryOnEror: { count: 3, delay: 500 } },
+		{ retryOnError: { count: 3, delay: 500 } },
 	);
 }
 ```


### PR DESCRIPTION
Fixes a typo in the `retryOnError` field in docs.