### PR TITLE
fix(ngx-control-value-accessor): accessing properties is outside of a reactive context

### DIFF
--- a/libs/ngxtension/control-value-accessor/src/control-value-accessor.spec.ts
+++ b/libs/ngxtension/control-value-accessor/src/control-value-accessor.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Provider, inject } from '@angular/core';
+import { Component, Provider, effect, inject } from '@angular/core';
 import { TestBed, fakeAsync, flush } from '@angular/core/testing';
 import {
 	FormControl,
@@ -208,6 +208,80 @@ describe('NgxControlValueAccessor', () => {
 		expect(fixture.debugElement.injector.get(NgControl)).toEqual(
 			'some mock control directive',
 		);
+	});
+
+	describe('accessing properties should be outside a reactive context', () => {
+		it('value', () => {
+			const { cva, fixture } = render(`<custom-input />`);
+
+			let effectCallCount = 0;
+
+			TestBed.runInInjectionContext(() => {
+				effect(() => {
+					effectCallCount++;
+
+					// accessing the value property should not register the internal signal
+					cva.value;
+				});
+			});
+
+			// initial effect execution
+			fixture.detectChanges();
+			expect(effectCallCount).toEqual(1);
+
+			// setting the value should not trigger the effect
+			cva.value = '123';
+			fixture.detectChanges();
+			expect(effectCallCount).toEqual(1);
+		});
+
+		it('disabled', () => {
+			const { cva, fixture } = render(`<custom-input />`);
+
+			let effectCallCount = 0;
+
+			TestBed.runInInjectionContext(() => {
+				effect(() => {
+					effectCallCount++;
+
+					// accessing the disabled property should not register the internal signal
+					cva.disabled;
+				});
+			});
+
+			// initial effect execution
+			fixture.detectChanges();
+			expect(effectCallCount).toEqual(1);
+
+			// setting the value should not trigger the effect
+			cva.disabled = !cva.disabled;
+			fixture.detectChanges();
+			expect(effectCallCount).toEqual(1);
+		});
+
+		it('compareTo', () => {
+			const { cva, fixture } = render(`<custom-input />`);
+
+			let effectCallCount = 0;
+
+			TestBed.runInInjectionContext(() => {
+				effect(() => {
+					effectCallCount++;
+
+					// accessing the compareTo property should not register the internal signal
+					cva.compareTo;
+				});
+			});
+
+			// initial effect execution
+			fixture.detectChanges();
+			expect(effectCallCount).toEqual(1);
+
+			// setting the value should not trigger the effect
+			cva.compareTo = () => true;
+			fixture.detectChanges();
+			expect(effectCallCount).toEqual(1);
+		});
 	});
 
 	describe('with a NgControl', () => {

--- a/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
+++ b/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
@@ -7,6 +7,7 @@ import {
 	inject,
 	runInInjectionContext,
 	signal,
+	untracked,
 	type OnInit,
 } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
@@ -271,7 +272,7 @@ export class NgxControlValueAccessor<T = any>
 	}
 
 	public get value() {
-		return this.value$();
+		return untracked(this.value$);
 	}
 
 	/** Whether this is disabled. If a control is present, it reflects it's disabled state. */
@@ -281,7 +282,7 @@ export class NgxControlValueAccessor<T = any>
 	}
 
 	public get disabled() {
-		return this.disabled$();
+		return untracked(this.disabled$);
 	}
 
 	/**
@@ -295,7 +296,7 @@ export class NgxControlValueAccessor<T = any>
 	}
 
 	public get compareTo() {
-		return this.compareTo$();
+		return untracked(this.compareTo$);
 	}
 
 	/**


### PR DESCRIPTION
fixes #547