### PR TITLE
refactor(ngx-control-value-accessor): use normal effect instead of rxEffect

### DIFF
--- a/libs/ngxtension/control-value-accessor/src/control-value-accessor.spec.ts
+++ b/libs/ngxtension/control-value-accessor/src/control-value-accessor.spec.ts
@@ -358,6 +358,7 @@ describe('NgxControlValueAccessor', () => {
 				expect(cva.disabled).toEqual(true);
 				expect(input.disabled).toEqual(true);
 
+				// verify sync of control.disabled => cva.disabled
 				params.control.enable();
 				fixture.detectChanges();
 
@@ -370,6 +371,7 @@ describe('NgxControlValueAccessor', () => {
 				expect(cva.disabled).toEqual(true);
 				expect(input.disabled).toEqual(true);
 
+				// verify sync of cva.disabled => control.disabled
 				cva.disabled = false;
 				fixture.detectChanges();
 				expect(params.control.disabled).toEqual(false);
@@ -450,6 +452,7 @@ describe('NgxControlValueAccessor', () => {
 				expect(cva.disabled).toEqual(true);
 				expect(input.disabled).toEqual(true);
 
+				// verify sync of control.disabled => cva.disabled
 				ngControl?.control!.enable();
 				fixture.detectChanges();
 
@@ -460,6 +463,17 @@ describe('NgxControlValueAccessor', () => {
 				fixture.detectChanges();
 
 				expect(cva.disabled).toEqual(true);
+				expect(input.disabled).toEqual(true);
+
+				// verify sync of cva.disabled => control.disabled
+				cva.disabled = false;
+				fixture.detectChanges();
+				expect(ngControl?.disabled).toEqual(false);
+				expect(input.disabled).toEqual(false);
+
+				cva.disabled = true;
+				fixture.detectChanges();
+				expect(ngControl?.disabled).toEqual(true);
 				expect(input.disabled).toEqual(true);
 			});
 		});

--- a/libs/ngxtension/control-value-accessor/src/control-value-accessor.spec.ts
+++ b/libs/ngxtension/control-value-accessor/src/control-value-accessor.spec.ts
@@ -369,6 +369,16 @@ describe('NgxControlValueAccessor', () => {
 
 				expect(cva.disabled).toEqual(true);
 				expect(input.disabled).toEqual(true);
+
+				cva.disabled = false;
+				fixture.detectChanges();
+				expect(params.control.disabled).toEqual(false);
+				expect(input.disabled).toEqual(false);
+
+				cva.disabled = true;
+				fixture.detectChanges();
+				expect(params.control.disabled).toEqual(true);
+				expect(input.disabled).toEqual(true);
 			});
 		});
 

--- a/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
+++ b/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
@@ -1,6 +1,5 @@
 import {
 	Directive,
-	Injector,
 	Input,
 	Output,
 	booleanAttribute,
@@ -195,9 +194,6 @@ export const provideCvaCompareToByProp = <T>(prop: keyof T) =>
 	standalone: true,
 })
 export class NgxControlValueAccessor<T = any> implements ControlValueAccessor {
-	/** @ignore */
-	private readonly injector = inject(Injector);
-
 	/**
 	 * The `NgControl` instance on this host element. If present, this `NgxControlValueAccessor` instance will be its value accessor.
 	 *

--- a/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
+++ b/libs/ngxtension/control-value-accessor/src/control-value-accessor.ts
@@ -239,14 +239,14 @@ export class NgxControlValueAccessor<T = any> implements ControlValueAccessor {
 	protected readonly notifyNgControlOnValueChanges = effect(() => {
 		const value = this.value$();
 
-		untracked(() => {
-			/**
-			 * no-op if THIS value is already _equal_ to the value of the control => we dont need to notify the control.
-			 */
-			if (this.compareTo(this.ngControl?.value, value)) {
-				return;
-			}
+		/**
+		 * no-op if THIS value is already _equal_ to the value of the control => we dont need to notify the control.
+		 */
+		if (this.compareTo(this.ngControl?.value, value)) {
+			return;
+		}
 
+		untracked(() => {
 			this.onChange(value);
 		});
 	});


### PR DESCRIPTION
rxEffect was just used in order to 'escape' setting signals in an effect back then when it was not allowed... this can be done now anyways and could have been done back then aswell, but I did not know at that time about the usage of a normal effect and untracked.

wait for #555