### PR TITLE
doc: create repeat, added the nonlibrary code equivalent

### DIFF
--- a/docs/src/content/docs/utilities/Operators/create-repeat.md
+++ b/docs/src/content/docs/utilities/Operators/create-repeat.md
@@ -20,8 +20,6 @@ Create an RxJS `repeat` operator with an `emit` method on it, to notify when the
 @Component({
   ...,
   template: `
-    ...
-
     <button (click)="repeat.emit()">Repeat</button>
   `
 })
@@ -30,6 +28,21 @@ export class SomeComponent {
 
   // Will log 'hello' directly, then each time the 'Repeat' button gets clicked
   readonly #sayHello = rxEffect(of('hello').pipe(this.repeat()), console.log);
+}
+```
+
+It is syntactic sugar for the following:
+
+```ts
+@Component({
+  ...,
+  template: `
+    <button (click)="repeat$.next()">Repeat</button>
+  `
+})
+export class SomeComponent {
+  readonly repeat$ = new Subject<void>();
+  readonly #sayHello = rxEffect(of('hello').pipe(repeat({ delay: () => repeat$ }), console.log);
 }
 ```
 


### PR DESCRIPTION
When browsing the library's documentation, I often find myself missing something: a native/non-library code example alongside the code that uses the library. This would help demonstrate the actual benefits each utility brings.

As an example, I've added the equivalent RxJS native code implementation next to the create-repeat code example.

Would you be interested in having more such before/after code comparisons in the documentation? If so, I'd be happy to create more examples for other utilities.

If you like the idea but would prefer a different approach, please let me know!