### PR TITLE
docs: Add missing entry in contributors

### DIFF
--- a/docs/src/content/contributors/pawel-ostromecki.json
+++ b/docs/src/content/contributors/pawel-ostromecki.json
@@ -1,0 +1,7 @@
+{
+	"name": "Paweł Ostromecki",
+	"twitter": "https://twitter.com/ostromeckyp",
+	"linkedin": "https://www.linkedin.com/in/ostromeckyp/",
+	"github": "https://github.com/ostromeckyp",
+	"website": "https://ostromecki.dev"
+}


### PR DESCRIPTION
Added missing entry in contributors so astro is able to render host binding docs correctly