### PR TITLE
feat: introduce takeLatestFrom()

### DIFF
--- a/docs/src/content/docs/utilities/Operators/take-latest-from.md
+++ b/docs/src/content/docs/utilities/Operators/take-latest-from.md
@@ -20,8 +20,12 @@ src$.pipe(whitLatestFrom(data$)).subscribe();
 
 Cases when `withLatestFrom()` will not emit when `src$` emits:
 
-- if `data$` is a cold observable and emitted before `src$` emitted - the next time `withLatestFrom()` will emit is when `data$` emits;
-- if `data$` emitted after `src$` emitted (`data$` can be hot or cold) - the next time `withLatestFrom()` will emit is when `src$` emits.
+- if `data$` is a cold observable and emitted before `src$` emitted;
+- if `data$` emitted after `src$` emitted (`data$` can be hot or cold).
+
+In the first case, `withLatestFrom()` will wait for the next `data$` value to emit, and `takeLatestFrom()` will do the same.
+
+In the second case, `withLatestFrom()` will wait for the next `src$` value to emit, and `takeLatestFrom()` will emit at the moment when `data$` emits its value.
 
 ## Usage
 

--- a/docs/src/content/docs/utilities/Operators/take-latest-from.md
+++ b/docs/src/content/docs/utilities/Operators/take-latest-from.md
@@ -1,0 +1,46 @@
+---
+title: takeLatestFrom
+description: ngxtension/take-latest-from
+entryPoint: ngxtension/take-latest-from
+badge: stable
+contributors: ['evgeniy-oz']
+---
+
+`takeLatestFrom()` is a modification of `withLatestFrom()` operator.
+
+Every time the source observable emits, `takeLatestFrom()` waits for the provided observables to emit a value, and when each of them has emitted, `takeLatestFrom()` emits and unsubscribes from the provided observables.
+
+## The Difference
+
+Let's say we have a source observable `src$` and a provided observable `data$`.
+
+```ts
+src$.pipe(whitLatestFrom(data$)).subscribe();
+```
+
+Cases when `withLatestFrom()` will not emit when `src$` emits:
+
+- if `data$` is a cold observable and emitted before `src$` emitted - the next time `withLatestFrom()` will emit is when `data$` emits;
+- if `data$` emitted after `src$` emitted (`data$` can be hot or cold) - the next time `withLatestFrom()` will emit is when `src$` emits.
+
+## Usage
+
+You would use `takeLatestFrom()` when you have some observable, and every time it emits, you want to attach the latest values from some other observables and handle them. If these other observables don't have a value yet, you would like to wait until they emit at least one value (each).
+
+### Example:
+
+```ts
+class ExampleStore {
+	private readonly dataSrv = inject(DataService);
+	private readonly userSrv = inject(UserService);
+
+	public readonly updateData = createEffect<DataType>((_) =>
+		_.pipe(
+			takeLatestFrom(() => [this.dataSrv.getData(), this.userSrv.getUser()]),
+			exhaustMap(([newData, oldData, user]) =>
+				this.dataSrv.updateData(merge({}, oldData, newData), user),
+			),
+		),
+	);
+}
+```

--- a/libs/ngxtension/take-latest-from/README.md
+++ b/libs/ngxtension/take-latest-from/README.md
@@ -1,0 +1,3 @@
+# ngxtension/take-latest-from
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/take-latest-from`.

--- a/libs/ngxtension/take-latest-from/ng-package.json
+++ b/libs/ngxtension/take-latest-from/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/take-latest-from/project.json
+++ b/libs/ngxtension/take-latest-from/project.json
@@ -1,0 +1,20 @@
+{
+	"name": "ngxtension/take-latest-from",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "libs/ngxtension/take-latest-from/src",
+	"targets": {
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "libs/ngxtension/jest.config.ts",
+				"testPathPattern": ["take-latest-from"]
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/libs/ngxtension/take-latest-from/src/index.ts
+++ b/libs/ngxtension/take-latest-from/src/index.ts
@@ -1,0 +1,1 @@
+export { takeLatestFrom } from './take-latest-from';

--- a/libs/ngxtension/take-latest-from/src/take-latest-from.spec.ts
+++ b/libs/ngxtension/take-latest-from/src/take-latest-from.spec.ts
@@ -1,0 +1,90 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { BehaviorSubject, map, shareReplay, Subject, timer } from 'rxjs';
+import { takeLatestFrom } from './take-latest-from';
+
+describe('takeLatestFrom', () => {
+	it('should emit when source emitted and hot observables emit later', fakeAsync(() => {
+		let result: string[] | undefined;
+
+		const source = new Subject<string>();
+		const obs1 = timer(100).pipe(
+			map(() => 'x'),
+			shareReplay({ bufferSize: 1, refCount: false }),
+		);
+		const obs2 = timer(200).pipe(
+			map(() => 'y'),
+			shareReplay({ bufferSize: 1, refCount: false }),
+		);
+
+		source.pipe(takeLatestFrom(() => [obs1, obs2])).subscribe((value) => {
+			result = value;
+		});
+
+		expect(result).toEqual(undefined);
+
+		source.next('a');
+
+		tick(200);
+		expect(result).toEqual(['a', 'x', 'y']);
+
+		source.next('b');
+		expect(result).toEqual(['b', 'x', 'y']);
+
+		source.next('c');
+		expect(result).toEqual(['c', 'x', 'y']);
+	}));
+
+	it('should emit when source emitted and hot observables have a value', fakeAsync(() => {
+		let result: string[] | undefined;
+
+		const source = new Subject<string>();
+		const obs1 = new BehaviorSubject('x');
+		const obs2 = new BehaviorSubject('y');
+
+		source.pipe(takeLatestFrom(() => [obs1, obs2])).subscribe((value) => {
+			result = value;
+		});
+
+		expect(result).toEqual(undefined);
+
+		source.next('a');
+
+		expect(result).toEqual(['a', 'x', 'y']);
+
+		source.next('b');
+		expect(result).toEqual(['b', 'x', 'y']);
+
+		source.next('c');
+		expect(result).toEqual(['c', 'x', 'y']);
+	}));
+
+	it('should emit when source emitted and cold observables emit later', fakeAsync(() => {
+		let result: string[] | undefined;
+
+		const source = new Subject<string>();
+		const obs1 = timer(100).pipe(map(() => 'x'));
+		const obs2 = timer(200).pipe(map(() => 'y'));
+
+		source.pipe(takeLatestFrom(() => [obs1, obs2])).subscribe((value) => {
+			result = value;
+		});
+
+		expect(result).toEqual(undefined);
+
+		source.next('a');
+
+		tick(200);
+		expect(result).toEqual(['a', 'x', 'y']);
+
+		source.next('b');
+		tick(200);
+		expect(result).toEqual(['b', 'x', 'y']);
+
+		tick(100);
+		expect(result).toEqual(['b', 'x', 'y']);
+
+		source.next('c');
+		tick(200);
+		expect(result).toEqual(['c', 'x', 'y']);
+	}));
+});

--- a/libs/ngxtension/take-latest-from/src/take-latest-from.ts
+++ b/libs/ngxtension/take-latest-from/src/take-latest-from.ts
@@ -1,0 +1,46 @@
+import {
+	combineLatestWith,
+	concatMap,
+	Observable,
+	ObservableInput,
+	ObservedValueOf,
+	of,
+	OperatorFunction,
+	take,
+} from 'rxjs';
+
+export function takeLatestFrom<T extends Observable<unknown>[], V>(
+	observablesFactory: (value: V) => [...T],
+): OperatorFunction<V, [V, ...{ [i in keyof T]: ObservedValueOf<T[i]> }]>;
+export function takeLatestFrom<T extends Observable<unknown>, V>(
+	observableFactory: (value: V) => T,
+): OperatorFunction<V, [V, ObservedValueOf<T>]>;
+
+/**
+ * Every time the source observable emits, `takeLatestFrom()` waits
+ * for the provided observables to emit a value, and when each of
+ * them has emitted, `takeLatestFrom()` emits and unsubscribes
+ * from the provided observables.
+ */
+export function takeLatestFrom<
+	T extends ObservableInput<unknown>[] | ObservableInput<unknown>,
+	V,
+	R = [
+		V,
+		...(T extends ObservableInput<unknown>[]
+			? { [i in keyof T]: ObservedValueOf<T[i]> }
+			: [ObservedValueOf<T>]),
+	],
+>(observablesFactory: (value: V) => T): OperatorFunction<V, R> {
+	return concatMap((value) => {
+		const observables = observablesFactory(value);
+		const observablesAsArray = Array.isArray(observables)
+			? observables
+			: [observables];
+
+		return of(value).pipe(
+			combineLatestWith(...observablesAsArray),
+			take(1),
+		) as unknown as Observable<R>;
+	});
+}

--- a/libs/ngxtension/take-latest-from/src/take-latest-from.ts
+++ b/libs/ngxtension/take-latest-from/src/take-latest-from.ts
@@ -1,11 +1,11 @@
 import {
 	combineLatestWith,
 	concatMap,
-	Observable,
-	ObservableInput,
-	ObservedValueOf,
+	type Observable,
+	type ObservableInput,
+	type ObservedValueOf,
 	of,
-	OperatorFunction,
+	type OperatorFunction,
 	take,
 } from 'rxjs';
 
@@ -21,6 +21,45 @@ export function takeLatestFrom<T extends Observable<unknown>, V>(
  * for the provided observables to emit a value, and when each of
  * them has emitted, `takeLatestFrom()` emits and unsubscribes
  * from the provided observables.
+ *
+ * Let's say we have a source observable `src$` and a provided observable `data$`.
+ *
+ * ```ts
+ * src$.pipe(whitLatestFrom(data$)).subscribe();
+ * ```
+ *
+ * Cases when `withLatestFrom()` will not emit when `src$` emits:
+ *
+ * - if `data$` is a cold observable and emitted before `src$` emitted;
+ * - if `data$` emitted after `src$` emitted (`data$` can be hot or cold).
+ *
+ * In the first case, `withLatestFrom()` will wait for the next `data$` value to emit,
+ * and `takeLatestFrom()` will do the same.
+ *
+ * In the second case, `withLatestFrom()` will wait for the next `src$` value to emit,
+ * and `takeLatestFrom()` will emit at the moment when `data$` emits its value.
+ *
+ * You would use `takeLatestFrom()` when you have some observable, and every time it emits,
+ * you want to attach the latest values from some other observables and handle them.
+ * If these other observables don't have a value yet, you would like to wait until they emit at least one value (each).
+ *
+ * Example:
+ *
+ * ```ts
+ * class ExampleStore {
+ *  private readonly dataSrv = inject(DataService);
+ *  private readonly userSrv = inject(UserService);
+ *
+ *  public readonly updateData = createEffect<DataType>((_) =>
+ *    _.pipe(
+ *      takeLatestFrom(() => [this.dataSrv.getData(), this.userSrv.getUser()]),
+ *      exhaustMap(([newData, oldData, user]) =>
+ *        this.dataSrv.updateData(merge({}, oldData, newData), user),
+ *      ),
+ *    ),
+ *  );
+ * }
+ * ```
  */
 export function takeLatestFrom<
 	T extends ObservableInput<unknown>[] | ObservableInput<unknown>,


### PR DESCRIPTION
`takeLatestFrom()` is a modification of `withLatestFrom()` operator.

Every time the source observable emits, `takeLatestFrom()` waits for the provided observables to emit a value, and when each of them has emitted, `takeLatestFrom()` emits and unsubscribes from the provided observables.

## The Difference

Let's say we have a source observable `src$` and a provided observable `data$`.

```ts
src$.pipe(
  whitLatestFrom(data$)
).subscribe();
```

Cases when `withLatestFrom()` will not emit when `src$` emits:

- if `data$` is a cold observable and emitted before `src$` emitted;
- if `data$` emitted after `src$` emitted (`data$` can be hot or cold).

In the first case, `withLatestFrom()` will wait for the next `data$` value to emit, and `takeLatestFrom()` will do the same.

In the second case, `withLatestFrom()` will wait for the next `src$` value to emit, and `takeLatestFrom()` will emit at the moment when `data$` emits its value.

## Usage

You would use `takeLatestFrom()` when you have some observable, and every time it emits, you want to attach the latest values from some other observables and handle them. If these other observables don't have a value yet, you would like to wait until they emit at least one value (each).

### Example:

```ts
class ExampleStore {
  private readonly dataSrv = inject(DataService);
  private readonly userSrv = inject(UserService);

  public readonly updateData = createEffect<DataType>((_) =>
    _.pipe(
      takeLatestFrom(() => [this.dataSrv.getData(), this.userSrv.getUser()]),
      exhaustMap(([newData, oldData, user]) =>
        this.dataSrv.updateData(merge({}, oldData, newData), user)
      ))
  );
}
```
