### PR TITLE
feat: publish ngxtension-plugin separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">NG Extension Platform</h1>
-<p align="center"> 
+<p align="center">
 <img src="/docs/public/ngxt-blue.svg" width="100px" height="100px">
 </p>
 
@@ -14,29 +14,15 @@ A collection of utilities for [Angular](https://angular.dev).
 
 ## Installation
 
-The `ng-add` schematic/generator installs the `ngxtension` package as well as turning on `skipLibCheck` TypeScript configuration if it hasn't been turned on.
-This allows your project to skip checking types for external libraries like `ngxtension` where typings might not be compatible with your project's strictness.
-
 ```shell
-ng add ngxtension
+npm install -D ngxtension-plugin
 ```
 
-or
+then invoke the `init` generator/schematic
 
 ```shell
-npm install ngxtension
-```
-
-```shell
-yarn add ngxtension
-```
-
-```shell
-pnpm install ngxtension
-```
-
-```shell
-nx generate ngxtension:init
+ng generate ngxtension-plugin:init
+# nx generate ngxtension-plugin:init
 ```
 
 ## Utilities

--- a/docs/src/content/docs/es/getting-started/installation.mdx
+++ b/docs/src/content/docs/es/getting-started/installation.mdx
@@ -9,47 +9,26 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Automático
 
-`ngxtension` viene con un esquematico/generador de inicialización tanto para Angular CLI como para [Nx](https://nx.dev).
-
-El esquematico/generador agrega `ngxtension` como una dependencia al proyecto y activa `skipLibCheck` para asegurar que los typings de librerias externas no fallen la rigurosidad del proyecto.
-
-#### Angular CLI
-
-```shell title="Adding ngxtension"
-ng add ngxtension
+```shell
+npm install -D ngxtension-plugin
 ```
-
-#### Nx CLI
 
 <Tabs>
-	<TabItem label="npm">
+ <TabItem label="ng">
 
-```shell title="Instalando ngxtension"
-  npm install ngxtension
+```shell title="Invocar el init generator"
+  ng g ngxtension-plugin:init
 ```
 
   </TabItem>
-	<TabItem label="yarn">
+ <TabItem label="nx">
 
-```shell title="Instalando ngxtension"
-yarn add ngxtension
-```
-
-  </TabItem>
-	<TabItem label="pnpm">
-
-```shell title="Instalando ngxtension"
-pnpm install ngxtension
+```shell title="Invocar el init generator"
+  nx g ngxtension-plugin:init
 ```
 
   </TabItem>
 </Tabs>
-
-Luego invoca el generador `ngxtension:init`
-
-```shell title="Invocar el init generator"
-nx g ngxtension:init
-```
 
 ### Manual
 

--- a/docs/src/content/docs/es/utilities/Migrations/inject-migration.md
+++ b/docs/src/content/docs/es/utilities/Migrations/inject-migration.md
@@ -170,19 +170,19 @@ export class AppComponent {
 Para ejecutar el schematics en todos los proyectos de la aplicación, tienemos que ejecutar el siguiente script:
 
 ```bash
-ng g ngxtension:convert-di-to-inject
+ng g ngxtension-plugin:convert-di-to-inject
 ```
 
 Si se precisa especificar el nombre del proyecto, podemos pasar el parámetro `--project`.
 
 ```bash
-ng g ngxtension:convert-di-to-inject --project=<project-name>
+ng g ngxtension-plugin:convert-di-to-inject --project=<project-name>
 ```
 
 Si necesitamos ejecutar el schematic para un componente o directiva específicos, podemos proporcionar el parámetro `--path`.
 
 ```bash
-ng g ngxtension:convert-di-to-inject --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-di-to-inject --path=<path-to-ts-file>
 ```
 
 ### Uso con Nx
@@ -192,5 +192,5 @@ Para usar el schematics con un monorepo Nx, podemos substituir `ng` por `nx`
 Ejemplo:
 
 ```bash
-nx g ngxtension:convert-di-to-inject --project=<project-name>
+nx g ngxtension-plugin:convert-di-to-inject --project=<project-name>
 ```

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -9,55 +9,26 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Automatic
 
-`ngxtension` comes with an initialize schematic/generator for both Angular CLI and [Nx](https://nx.dev)
-
-The schematic/generator adds `ngxtension` as a dependency to the project as well as turning on `skipLibCheck` to ensure
-typings from external libraries do not fail the project's strictness.
-
-#### Angular CLI
-
-```shell title="Adding ngxtension"
-ng add ngxtension
+```shell
+npm install -D ngxtension-plugin
 ```
-
-#### Nx CLI
 
 <Tabs>
-	<TabItem label="npm">
+ <TabItem label="ng">
 
-```shell title="Installing ngxtension"
-npm install ngxtension
+```shell title="Invoking init generator"
+  ng g ngxtension-plugin:init
 ```
 
   </TabItem>
-	<TabItem label="yarn">
+ <TabItem label="nx">
 
-```shell title="Installing ngxtension"
-yarn add ngxtension
-```
-
-  </TabItem>
-	<TabItem label="pnpm">
-
-```shell title="Installing ngxtension"
-pnpm install ngxtension
-```
-
-  </TabItem>
-	<TabItem label="bun">
-
-```shell title="Installing ngxtension"
-bun add ngxtension
+```shell title="Invoking init generator"
+  nx g ngxtension-plugin:init
 ```
 
   </TabItem>
 </Tabs>
-
-Then invoke the `ngxtension:init` generator
-
-```shell title="Invoking init generator"
-nx g ngxtension:init
-```
 
 ### Manual
 

--- a/docs/src/content/docs/utilities/Migrations/host-binding-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/host-binding-migration.md
@@ -69,19 +69,19 @@ export class CustomSlider {
 In order to run the schematics for all the project in the app you have to run the following script:
 
 ```bash
-ng g ngxtension:convert-host-binding
+ng g ngxtension-plugin:convert-host-binding
 ```
 
 If you want to specify the project name you can pass the `--project` param.
 
 ```bash
-ng g ngxtension:convert-host-binding --project=<project-name>
+ng g ngxtension-plugin:convert-host-binding --project=<project-name>
 ```
 
 If you want to run the schematic for a specific component or directive you can pass the `--path` param.
 
 ```bash
-ng g ngxtension:convert-host-binding --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-host-binding --path=<path-to-ts-file>
 ```
 
 ### Usage with Nx
@@ -91,5 +91,5 @@ To use the schematics on a Nx monorepo you just swap `ng` with `nx`
 Example:
 
 ```bash
-nx g ngxtension:convert-host-binding --project=<project-name>
+nx g ngxtension-plugin:convert-host-binding --project=<project-name>
 ```

--- a/docs/src/content/docs/utilities/Migrations/inject-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/inject-migration.md
@@ -196,19 +196,19 @@ export class AppComponent {
 In order to run the schematics for all the project in the app you have to run the following script:
 
 ```bash
-ng g ngxtension:convert-di-to-inject
+ng g ngxtension-plugin:convert-di-to-inject
 ```
 
 If you want to specify the project name you can pass the `--project` param.
 
 ```bash
-ng g ngxtension:convert-di-to-inject --project=<project-name>
+ng g ngxtension-plugin:convert-di-to-inject --project=<project-name>
 ```
 
 If you want to run the schematic for a specific component or directive you can pass the `--path` param.
 
 ```bash
-ng g ngxtension:convert-di-to-inject --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-di-to-inject --path=<path-to-ts-file>
 ```
 
 ### Usage with Nx
@@ -218,5 +218,5 @@ To use the schematics on a Nx monorepo you just swap `ng` with `nx`
 Example:
 
 ```bash
-nx g ngxtension:convert-di-to-inject --project=<project-name>
+nx g ngxtension-plugin:convert-di-to-inject --project=<project-name>
 ```

--- a/docs/src/content/docs/utilities/Migrations/new-outputs-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/new-outputs-migration.md
@@ -82,19 +82,19 @@ _someSubject = outputFromObservable(this.someSubject, { alias: 'someSubject' });
 In order to run the schematics for all the project in the app you have to run the following script:
 
 ```bash
-ng g ngxtension:convert-outputs
+ng g ngxtension-plugin:convert-outputs
 ```
 
 If you want to specify the project name you can pass the `--project` param.
 
 ```bash
-ng g ngxtension:convert-outputs --project=<project-name>
+ng g ngxtension-plugin:convert-outputs --project=<project-name>
 ```
 
 If you want to run the schematic for a specific component or directive you can pass the `--path` param.
 
 ```bash
-ng g ngxtension:convert-outputs --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-outputs --path=<path-to-ts-file>
 ```
 
 ### Usage with Nx
@@ -104,5 +104,5 @@ To use the schematics on a Nx monorepo you just swap `ng` with `nx`
 Example:
 
 ```bash
-nx g ngxtension:convert-outputs --project=<project-name>
+nx g ngxtension-plugin:convert-outputs --project=<project-name>
 ```

--- a/docs/src/content/docs/utilities/Migrations/queries-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/queries-migration.md
@@ -93,19 +93,19 @@ export class AppComponent {
 In order to run the schematics for all the project in the app you have to run the following script:
 
 ```bash
-ng g ngxtension:convert-queries
+ng g ngxtension-plugin:convert-queries
 ```
 
 If you want to specify the project name you can pass the `--project` param.
 
 ```bash
-ng g ngxtension:convert-queries --project=<project-name>
+ng g ngxtension-plugin:convert-queries --project=<project-name>
 ```
 
 If you want to run the schematic for a specific component or directive you can pass the `--path` param.
 
 ```bash
-ng g ngxtension:convert-queries --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-queries --path=<path-to-ts-file>
 ```
 
 ### Usage with Nx
@@ -115,5 +115,5 @@ To use the schematics on a Nx monorepo you just swap `ng` with `nx`
 Example:
 
 ```bash
-nx g ngxtension:convert-queries --project=<project-name>
+nx g ngxtension-plugin:convert-queries --project=<project-name>
 ```

--- a/docs/src/content/docs/utilities/Migrations/self-closing-tags.md
+++ b/docs/src/content/docs/utilities/Migrations/self-closing-tags.md
@@ -21,19 +21,19 @@ The moment you run the schematics, it will look for all the tags that are not se
 In order to run the schematics for all the project in the app you have to run the following script:
 
 ```bash
-ng g ngxtension:convert-to-self-closing-tag
+ng g ngxtension-plugin:convert-to-self-closing-tag
 ```
 
 If you want to specify the project name you can pass the `--project` param.
 
 ```bash
-ng g ngxtension:convert-to-self-closing-tag --project=<project-name>
+ng g ngxtension-plugin:convert-to-self-closing-tag --project=<project-name>
 ```
 
 If you want to run the schematic for a specific component or directive you can pass the `--path` param.
 
 ```bash
-ng g ngxtension:convert-to-self-closing-tag --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-to-self-closing-tag --path=<path-to-ts-file>
 ```
 
 ### Usage with Nx
@@ -43,5 +43,5 @@ To use the schematics on a Nx monorepo you just swap `ng` with `nx`
 Example:
 
 ```bash
-nx g ngxtension:convert-to-self-closing-tag --project=<project-name>
+nx g ngxtension-plugin:convert-to-self-closing-tag --project=<project-name>
 ```

--- a/docs/src/content/docs/utilities/Migrations/sfc-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/sfc-migration.md
@@ -26,25 +26,25 @@ In order to change the maximum line length, you can pass the `--max-inline-templ
 In order to run the schematics for all the project in the app you have to run the following script:
 
 ```bash
-ng g ngxtension:convert-to-sfc
+ng g ngxtension-plugin:convert-to-sfc
 ```
 
 If you want to specify the project name you can pass the `--project` param.
 
 ```bash
-ng g ngxtension:convert-to-sfc --project=<project-name>
+ng g ngxtension-plugin:convert-to-sfc --project=<project-name>
 ```
 
 If you want to run the schematic for a specific component or directive you can pass the `--path` param.
 
 ```bash
-ng g ngxtension:convert-to-sfc --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-to-sfc --path=<path-to-ts-file>
 ```
 
 If you want to change the maximum line length for the template or styles you can pass the `--max-inline-template-lines` param or `--max-inline-style-lines` param.
 
 ```bash
-ng g ngxtension:convert-to-sfc --max-inline-template-lines=100 --max-inline-style-lines=100
+ng g ngxtension-plugin:convert-to-sfc --max-inline-template-lines=100 --max-inline-style-lines=100
 ```
 
 ### Usage with Nx
@@ -54,5 +54,5 @@ To use the schematics on a Nx monorepo you just swap `ng` with `nx`
 Example:
 
 ```bash
-nx g ngxtension:convert-to-sfc --project=<project-name>
+nx g ngxtension-plugin:convert-to-sfc --project=<project-name>
 ```

--- a/docs/src/content/docs/utilities/Migrations/signal-inputs-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/signal-inputs-migration.md
@@ -24,19 +24,19 @@ The moment you run the schematics, it will look for all the decorators that have
 In order to run the schematics for all the project in the app you have to run the following script:
 
 ```bash
-ng g ngxtension:convert-signal-inputs
+ng g ngxtension-plugin:convert-signal-inputs
 ```
 
 If you want to specify the project name you can pass the `--project` param.
 
 ```bash
-ng g ngxtension:convert-signal-inputs --project=<project-name>
+ng g ngxtension-plugin:convert-signal-inputs --project=<project-name>
 ```
 
 If you want to run the schematic for a specific component or directive you can pass the `--path` param.
 
 ```bash
-ng g ngxtension:convert-signal-inputs --path=<path-to-ts-file>
+ng g ngxtension-plugin:convert-signal-inputs --path=<path-to-ts-file>
 ```
 
 ### Usage with Nx
@@ -46,5 +46,5 @@ To use the schematics on a Nx monorepo you just swap `ng` with `nx`
 Example:
 
 ```bash
-nx g ngxtension:convert-signal-inputs --project=<project-name>
+nx g ngxtension-plugin:convert-signal-inputs --project=<project-name>
 ```

--- a/libs/ngxtension/README.md
+++ b/libs/ngxtension/README.md
@@ -4,29 +4,15 @@ A collection of utilities for [Angular](https://angular.dev).
 
 ## Installation
 
-The `ng-add` schematic/generator installs the `ngxtension` package as well as turning on `skipLibCheck` TypeScript configuration if it hasn't been turned on.
-This allows your project to skip checking types for external libraries like `ngxtension` where typings might not be compatible with your project's strictness.
-
 ```shell
-ng add ngxtension
+npm install -D ngxtension-plugin
 ```
 
-or
-
-```shell
-npm install ngxtension
 ```
 
 ```shell
-yarn add ngxtension
-```
-
-```shell
-pnpm install ngxtension
-```
-
-```shell
-nx generate ngxtension:init
+ng generate ngxtension-plugin:init
+# nx generate ngxtension-plugin:init
 ```
 
 ## Utilities

--- a/libs/ngxtension/ng-package.json
+++ b/libs/ngxtension/ng-package.json
@@ -3,11 +3,5 @@
 	"dest": "../../dist/libs/ngxtension",
 	"lib": {
 		"entryFile": "src/index.ts"
-	},
-	"allowedNonPeerDependencies": [
-		"@nx/devkit",
-		"nx",
-		"ts-morph",
-		"@angular-eslint/bundled-angular-compiler"
-	]
+	}
 }

--- a/libs/ngxtension/package.json
+++ b/libs/ngxtension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ngxtension",
 	"description": "Utilities library for Angular",
-	"version": "0.0.0",
+	"version": "0.0.0-replace",
 	"engines": {
 		"node": ">=18"
 	},
@@ -29,19 +29,7 @@
 		}
 	},
 	"dependencies": {
-		"tslib": "^2.3.0",
-		"@angular-eslint/bundled-angular-compiler": "^18.0.1",
-		"@nx/devkit": "^20.0.0",
-		"nx": "^20.0.0",
-		"ts-morph": "^22.0.0"
+		"tslib": "^2.3.0"
 	},
-	"sideEffects": false,
-	"generators": "./plugin/generators.json",
-	"schematics": "./plugin/generators.json",
-	"nx-migrations": {
-		"migrations": "./plugin/migrations.json"
-	},
-	"ng-update": {
-		"migrations": "./plugin/migrations.json"
-	}
+	"sideEffects": false
 }

--- a/libs/plugin/generators.json
+++ b/libs/plugin/generators.json
@@ -44,11 +44,6 @@
 		}
 	},
 	"schematics": {
-		"ng-add": {
-			"factory": "./src/generators/init/compat",
-			"schema": "./src/generators/init/schema.json",
-			"description": "Init ngxtension"
-		},
 		"init": {
 			"factory": "./src/generators/init/compat",
 			"schema": "./src/generators/init/schema.json",

--- a/libs/plugin/package.json
+++ b/libs/plugin/package.json
@@ -1,6 +1,28 @@
 {
+	"name": "ngxtension-plugin",
+	"version": "0.0.0-replace",
 	"type": "commonjs",
+	"dependencies": {
+		"@angular-eslint/bundled-angular-compiler": "^18.0.1",
+		"@nx/devkit": "^20.0.0",
+		"nx": "^20.0.0",
+		"ts-morph": "^22.0.0"
+	},
+	"main": "./src/index.js",
+	"types": "./src/index.d.ts",
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./src/index.d.ts",
+			"default": "./src/index.js"
+		},
+		"./generators": {
+			"types": "./src/generators/index.d.ts",
+			"default": "./src/generators/index.js"
+		}
+	},
 	"generators": "./generators.json",
+	"schematics": "./generators.json",
 	"nx-migrations": {
 		"migrations": "./migrations.json"
 	},

--- a/libs/plugin/project.json
+++ b/libs/plugin/project.json
@@ -8,7 +8,7 @@
 			"executor": "@nx/js:tsc",
 			"outputs": ["{options.outputPath}"],
 			"options": {
-				"outputPath": "dist/libs/ngxtension/plugin",
+				"outputPath": "dist/libs/plugin",
 				"main": "libs/plugin/src/index.ts",
 				"tsConfig": "libs/plugin/tsconfig.lib.json",
 				"assets": [
@@ -34,8 +34,7 @@
 						"output": "."
 					}
 				]
-			},
-			"dependsOn": [{ "target": "build", "projects": "ngxtension" }]
+			}
 		},
 		"lint": {
 			"executor": "@nx/eslint:lint",
@@ -46,6 +45,11 @@
 			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
 			"options": {
 				"jestConfig": "libs/plugin/jest.config.ts"
+			}
+		},
+		"nx-release-publish": {
+			"options": {
+				"packageRoot": "dist/{projectRoot}"
 			}
 		}
 	},

--- a/libs/plugin/src/generators/init/generator.ts
+++ b/libs/plugin/src/generators/init/generator.ts
@@ -14,8 +14,8 @@ export async function initGenerator(tree: Tree) {
 	const packageJson = readJson(tree, 'package.json');
 
 	const version =
-		packageJson['dependencies']?.['ngxtension'] ||
-		packageJson['devDependencies']?.['ngxtension'] ||
+		packageJson['dependencies']?.['ngxtension-plugin'] ||
+		packageJson['devDependencies']?.['ngxtension-plugin'] ||
 		'latest';
 
 	addDependenciesToPackageJson(tree, { ngxtension: version }, {});

--- a/nx.json
+++ b/nx.json
@@ -72,7 +72,7 @@
 		}
 	},
 	"release": {
-		"projects": ["ngxtension"],
+		"projects": ["ngxtension", "plugin"],
 		"version": {
 			"preVersionCommand": "npm run package"
 		},


### PR DESCRIPTION
This publishes `ngxtension-plugin` as an npm package separately.

Closes #410

BREAKING CHANGE:
`ngxtension` no longer contains the generators/schematics.
- If you set up scripts / commands that use `ngxtension` generators/schematics, please install `ngxtension-plugin` under `devDependencies` and use `ngxtension-plugin` generators/schematics instead.
- If you use `initGenerator` programmatically from `ngxtension`, please update your import to `ngxtension-plugin`