### PR TITLE
Updated sfc-migration documentation with adding missed parameters

### DIFF
--- a/docs/src/content/docs/utilities/Migrations/sfc-migration.md
+++ b/docs/src/content/docs/utilities/Migrations/sfc-migration.md
@@ -14,7 +14,7 @@ This schematic helps you convert your Angular components to SFC components.
 The moment you run the schematics, it will look for all the components in your project and will convert them to SFC components.
 
 - It will move the template from the `templateUrl` to the `template` property.
-- It will move the styles from the `styleUrls` to the `styles` property.
+- If the `--move-styles` param is enabled it will move also the styles from the `styleUrls` to the `styles` property.
 - The maximum lines length for the template is set to 200 lines. If the template has more than 200 lines, it will be skipped.
 
 In order to change the maximum line length, you can pass the `--max-inline-template-lines` param to the schematics. For styles, you can pass the `--max-inline-style-lines` param.
@@ -41,10 +41,16 @@ If you want to run the schematic for a specific component or directive you can p
 ng g ngxtension-plugin:convert-to-sfc --path=<path-to-ts-file>
 ```
 
+If you want to inline styles file as well you can set `--move-styles` param.
+
+```bash
+ng g ngxtension-plugin:convert-to-sfc --move-styles
+```
+
 If you want to change the maximum line length for the template or styles you can pass the `--max-inline-template-lines` param or `--max-inline-style-lines` param.
 
 ```bash
-ng g ngxtension-plugin:convert-to-sfc --max-inline-template-lines=100 --max-inline-style-lines=100
+ng g ngxtension-plugin:convert-to-sfc --max-inline-template-lines=100 --max-inline-style-lines=100 --move-styles
 ```
 
 ### Usage with Nx


### PR DESCRIPTION
Updated the sfc-migration documentation according to that issue #549:
Now there is the flag `--move-styles` mentioned