### PR TITLE
feat!: createEffect() upgrade

### DIFF
--- a/libs/ngxtension/create-effect/src/create-effect.ts
+++ b/libs/ngxtension/create-effect/src/create-effect.ts
@@ -1,32 +1,47 @@
-import {
-	DestroyRef,
-	Injector,
-	inject,
-	isSignal,
-	runInInjectionContext,
-	type Signal,
-} from '@angular/core';
+import { DestroyRef, type Injector, isSignal, runInInjectionContext, type Signal, } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { assertInjector } from 'ngxtension/assert-injector';
 import {
-	Observable,
-	Subject,
-	Subscription,
-	isObservable,
-	of,
-	retry,
-	type RetryConfig,
+  from,
+  isObservable,
+  of,
+  retry,
+  skipWhile,
+  Subject,
+  take,
+  type Observable,
+  type RetryConfig,
+  type Subscription,
 } from 'rxjs';
 
 export type CreateEffectOptions = {
-	injector?: Injector;
-	/**
-	 * @param retryOnError
-	 * Set to 'false' to disable retrying on error.
-	 * Otherwise, generated effect will use `retry()`.
-	 * You can pass `RetryConfig` object here to configure `retry()` operator.
-	 */
-	retryOnError?: boolean | RetryConfig;
+  injector?: Injector,
+  /**
+   * @param retryOnError
+   * This param allows your effect keep running on error.
+   * When set to `false`, any non-caught error will terminate the effect and consequent calls will be ignored.
+   * Otherwise, generated effect will use `retry()`.
+   * You can pass `RetryConfig` object here to configure `retry()` operator.
+   */
+  retryOnError?: boolean | RetryConfig,
+};
+
+export type EffectMethods<ObservableType> = {
+  asObservable: (observableOrValue?: ObservableType | Observable<ObservableType> | Signal<ObservableType> | Promise<ObservableType>) => Observable<unknown>,
+};
+
+export type EffectListeners = {
+  next?: (v: unknown) => void,
+  onSuccess?: (v?: unknown) => void,
+  error?: (v: unknown) => void,
+  onError?: (v?: unknown) => void,
+  complete?: () => void,
+  onFinalize?: () => void,
+};
+
+export type EffectCallbacks = {
+  success: (v?: unknown) => void,
+  error: (e?: unknown) => void,
 };
 
 /**
@@ -42,69 +57,140 @@ export type CreateEffectOptions = {
  * https://ngrx.io/guide/component-store/effect#effect-method
  */
 export function createEffect<
-	ProvidedType = void,
-	OriginType extends
-		| Observable<ProvidedType>
-		| unknown = Observable<ProvidedType>,
-	ObservableType = OriginType extends Observable<infer A> ? A : never,
-	ReturnType = ProvidedType | ObservableType extends void
-		? (
-				observableOrValue?:
-					| ObservableType
-					| Observable<ObservableType>
-					| Signal<ObservableType>,
-			) => Subscription
-		: (
-				observableOrValue:
-					| ObservableType
-					| Observable<ObservableType>
-					| Signal<ObservableType>,
-			) => Subscription,
->(
-	generator: (origin$: OriginType) => Observable<unknown>,
-	options?: CreateEffectOptions,
-): ReturnType {
+  ProvidedType = void,
+  OriginType extends | Observable<ProvidedType> | unknown = Observable<ProvidedType>,
+  ObservableType = OriginType extends Observable<infer A> ? A : never,
+  ReturnType = ProvidedType | ObservableType extends void
+    ? (
+      observableOrValue?: ObservableType | Observable<ObservableType> | Signal<ObservableType> | Promise<ObservableType>,
+      next?: ((v: unknown) => void) | EffectListeners
+    ) => Subscription
+    : (
+      observableOrValue: ObservableType | Observable<ObservableType> | Signal<ObservableType> | Promise<ObservableType>,
+      next?: ((v: unknown) => void) | EffectListeners
+    ) => Subscription
+>(generator: (origin$: OriginType, callbacks: EffectCallbacks) => Observable<unknown>, options?: CreateEffectOptions): ReturnType & EffectMethods<ObservableType> {
 	const injector = assertInjector(createEffect, options?.injector);
 	return runInInjectionContext(injector, () => {
-		const destroyRef = inject(DestroyRef);
-		const origin$ = new Subject<ObservableType>();
-		const retryOnError = !!(options?.retryOnError ?? true);
-		const retryConfig =
-			typeof options?.retryOnError === 'object' && options?.retryOnError
-				? options?.retryOnError
-				: ({} as RetryConfig);
+    const destroyRef = injector.get(DestroyRef);
+    const origin$ = new Subject<ObservableType>();
+    const retryOnError = options?.retryOnError ?? true;
+    const retryConfig = (typeof options?.retryOnError === 'object' && options?.retryOnError) ? options?.retryOnError : {} as RetryConfig;
 
-		if (retryOnError) {
-			generator(origin$ as OriginType)
-				.pipe(retry(retryConfig), takeUntilDestroyed(destroyRef))
-				.subscribe();
-		} else {
-			generator(origin$ as OriginType)
-				.pipe(takeUntilDestroyed(destroyRef))
-				.subscribe();
-		}
+    const nextValue = new Subject<unknown>();
+    const onSuccess = new Subject<unknown>();
+    const nextError = new Subject<unknown>();
+    const onError = new Subject<unknown>();
+    const complete = new Subject<void>();
+    const onFinalize = new Subject<void>();
 
-		return ((
-			observableOrValue?: ObservableType | Observable<ObservableType>,
-		): Subscription => {
-			const observable$ = isObservable(observableOrValue)
-				? observableOrValue
-				: isSignal(observableOrValue)
-					? toObservable(observableOrValue, { injector })
-					: of(observableOrValue);
-			if (retryOnError) {
-				return observable$
-					.pipe(retry(retryConfig), takeUntilDestroyed(destroyRef))
-					.subscribe((value) => {
-						origin$.next(value as ObservableType);
-					});
-			} else {
-				return observable$
-					.pipe(takeUntilDestroyed(destroyRef))
-					.subscribe((value) => {
-						origin$.next(value as ObservableType);
-					});
-			}
-		}) as unknown as ReturnType;
+    const callbacks: EffectCallbacks = {
+      success: (v) => {
+        onSuccess.next(v);
+        onFinalize.next();
+      },
+      error: (e) => {
+        onError.next(e);
+        onFinalize.next();
+      }
+    };
+
+    const generated = generator(origin$ as OriginType, callbacks);
+
+    (retryOnError ? generated.pipe(
+      retry(retryConfig),
+      takeUntilDestroyed(destroyRef)
+    ) : generated.pipe(
+      takeUntilDestroyed(destroyRef)
+    )).subscribe({
+      next: (v) => nextValue.next(v),
+      error: (e) => nextError.next(e),
+      complete: () => complete.next(),
+    });
+
+    const effectFn = ((
+      value?: ObservableType | Observable<ObservableType> | Signal<ObservableType> | Promise<ObservableType>,
+      next?: ((v: unknown) => void) | EffectListeners
+    ): Subscription => {
+      if (next) {
+        if (typeof next === 'function') {
+          nextValue.pipe(take(1), takeUntilDestroyed(destroyRef)).subscribe((v) => next(v));
+        } else {
+          if (next.next && typeof next.next === 'function') {
+            nextValue.pipe(take(1), takeUntilDestroyed(destroyRef)).subscribe((v) => next.next?.(v));
+          }
+          if (next.onSuccess && typeof next.onSuccess === 'function') {
+            onSuccess.pipe(take(1), takeUntilDestroyed(destroyRef)).subscribe((v) => next.onSuccess?.(v));
+          }
+          if (next.error && typeof next.error === 'function') {
+            nextError.pipe(take(1), takeUntilDestroyed(destroyRef)).subscribe((e) => next.error?.(e));
+          }
+          if (next.onError && typeof next.onError === 'function') {
+            onError.pipe(take(1), takeUntilDestroyed(destroyRef)).subscribe((e) => next.onError?.(e));
+          }
+          if (next.complete && typeof next.complete === 'function') {
+            complete.pipe(take(1), takeUntilDestroyed(destroyRef)).subscribe(() => next.complete?.());
+          }
+          if (next.onFinalize && typeof next.onFinalize === 'function') {
+            onFinalize.pipe(take(1), takeUntilDestroyed(destroyRef)).subscribe(() => next.onFinalize?.());
+          }
+        }
+      }
+
+      let firstSignalValue = undefined;
+      try {
+        if (isSignal(value)) {
+          firstSignalValue = value();
+          origin$.next(firstSignalValue);
+        }
+      } catch (_) {
+        // Angular's `input.required()` will throw an error when a signal's
+        // value is requested before the input's value is set.
+      }
+
+      const observable$ = isObservable(value)
+        ? value
+        : (isSignal(value)
+            ? toObservable(value, { injector }).pipe(skipWhile((v) => v === firstSignalValue))
+            : isPromise(value) ? from(value) : of(value)
+        );
+
+      return observable$.pipe(
+        takeUntilDestroyed(destroyRef)
+      ).subscribe((value) => {
+        origin$.next(value as ObservableType);
+      });
+    }) as ReturnType;
+
+    Object.defineProperty(effectFn, 'asObservable', {
+      get: () => (value?: ObservableType | Observable<ObservableType> | Signal<ObservableType> | Promise<ObservableType>) => {
+
+        let firstSignalValue = undefined;
+        try {
+          if (isSignal(value)) {
+            firstSignalValue = value();
+            origin$.next(firstSignalValue);
+          }
+        } catch (_) {
+          // Angular's `input.required()` will throw an error when a signal's
+          // value is requested before the input's value is set.
+        }
+
+        const observable$ = isObservable(value)
+          ? value
+          : (isSignal(value)
+              ? toObservable(value, { injector }).pipe(skipWhile((v) => v === firstSignalValue))
+              : isPromise(value) ? from(value) : of(value)
+          );
+        return generator(observable$ as OriginType, callbacks);
+      },
+      configurable: false
+    });
+
+    return effectFn as ReturnType & EffectMethods<ObservableType>;
 	});
+}
+
+function isPromise<T = unknown>(obj: unknown): obj is Promise<T> {
+  return !!obj && typeof obj === 'object' && ('then' in obj) && typeof obj.then === 'function';
 }


### PR DESCRIPTION
* Support Promise as input value;
* The generator callback now has the second argument, `callbacks`. It contains an object with callbacks `success` and `error` - the observable you provide to `createEffect()` can use them to notify the effect caller;
* The second argument of `createEffect()` got new fields:
* * `onSuccess?: (v?: unknown) => void` - will be called when `callbacks.success` is called;
* * `onError?: (v?: unknown) => void` - will be called when `callbacks.error` is called;
* * `onFinalize?: () => void` - will be called when either `callbacks.success` or `callbacks.error` is called;
* When a signal is passed to the function created by `createEffect()`, the effect handler is called synchronously and will not be called again with the same value (equal by reference, `===`) when the underlying `effect()` is executed.

**BREAKING CHANGE:**
Previously, `createEffect()` would re-subscribe when the effect's handler threw an error, and when the observable passed to the handler threw an error. Now it will only re-subscribe to the handler. If a passed observable throws an error, the effect will not re-subscribe to that observable - you will need to call the effect again. Re-subscribing to an observable that is in an error state might cause endless loops and unexpected behavior.