### PR TITLE
feat(inject-leaf-activated-route): add injectLeafActivatedRoute function and related types

### DIFF
--- a/libs/ngxtension/inject-leaf-activated-route/README.md
+++ b/libs/ngxtension/inject-leaf-activated-route/README.md
@@ -1,0 +1,3 @@
+# ngxtension/inject-leaf-activated-route
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/inject-leaf-activated-route`.

--- a/libs/ngxtension/inject-leaf-activated-route/ng-package.json
+++ b/libs/ngxtension/inject-leaf-activated-route/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/inject-leaf-activated-route/src/index.ts
+++ b/libs/ngxtension/inject-leaf-activated-route/src/index.ts
@@ -1,0 +1,1 @@
+export * from './inject-leaf-activated-route';

--- a/libs/ngxtension/inject-leaf-activated-route/src/inject-leaf-activated-route.ts
+++ b/libs/ngxtension/inject-leaf-activated-route/src/inject-leaf-activated-route.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { injectNavigationEnd } from 'ngxtension/navigation-end';
+import { map } from 'rxjs';
+
+export function injectLeafActivatedRoute() {
+	const router = inject(Router);
+	const navigationEnd$ = injectNavigationEnd();
+
+	const walkToDeepest = (step: ActivatedRoute): ActivatedRoute =>
+		step.firstChild ? walkToDeepest(step.firstChild) : step;
+
+	return toSignal(
+		navigationEnd$.pipe(map(() => walkToDeepest(router.routerState.root))),
+		{
+			initialValue: walkToDeepest(router.routerState.root),
+			// Behave 1:1 how your application's router is setup
+			// @see [OnSameUrlNavigation ignore](https://angular.dev/api/router/OnSameUrlNavigation)
+			equal: () => false,
+		},
+	);
+}

--- a/libs/ngxtension/inject-route-data/src/inject-route-data.ts
+++ b/libs/ngxtension/inject-route-data/src/inject-route-data.ts
@@ -1,11 +1,20 @@
 import { inject, type Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, type Data } from '@angular/router';
+import { injectLeafActivatedRoute } from 'libs/ngxtension/inject-leaf-activated-route/src/inject-leaf-activated-route';
 import { assertInjector } from 'ngxtension/assert-injector';
 import { DefaultValueOptions, InjectorOptions } from 'ngxtension/shared';
 import { map } from 'rxjs';
 
 type RouteDataTransformFn<T> = (data: Data) => T;
+
+export type RouteDataFromNavigationEndOptions = {
+	/**
+	 * Retrieve data from the leaf `ActivatedRoute` of the latest `NavigationEnd` event.
+	 * Essentially, this resolve to all route data, instead of only the route data of the current route level.
+	 */
+	fromNavigationEnd?: boolean;
+};
 
 /**
  * The `RouteDataOptions` type defines options for configuring the behavior of the `injectRouteData` function.
@@ -15,7 +24,9 @@ type RouteDataTransformFn<T> = (data: Data) => T;
  * @template DefaultValueT - The type of the default value.
  */
 export type RouteDataOptions<DefaultValueT> =
-	DefaultValueOptions<DefaultValueT> & InjectorOptions;
+	DefaultValueOptions<DefaultValueT> &
+		RouteDataFromNavigationEndOptions &
+		InjectorOptions;
 
 /**
  * The `injectRouteData` function allows you to access and manipulate route data from the current route.
@@ -59,7 +70,10 @@ export function injectRouteData<T>(
 	options: RouteDataOptions<T> = {},
 ) {
 	return assertInjector(injectRouteData, options?.injector, () => {
-		const route = inject(ActivatedRoute);
+		const route = options.fromNavigationEnd
+			? injectLeafActivatedRoute()()
+			: inject(ActivatedRoute);
+
 		const initialRouteData = route.snapshot.data || {};
 		const { defaultValue } = options;
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -96,6 +96,9 @@
 				"libs/ngxtension/inject-is-intersecting/src/index.ts"
 			],
 			"ngxtension/inject-lazy": ["libs/ngxtension/inject-lazy/src/index.ts"],
+			"ngxtension/inject-leaf-activated-route": [
+				"libs/ngxtension/inject-leaf-activated-route/src/index.ts"
+			],
 			"ngxtension/inject-local-storage": [
 				"libs/ngxtension/inject-local-storage/src/index.ts"
 			],


### PR DESCRIPTION
Closes #557 #381

This has not been tested yet, waiting for feedback. Inspired by [`injectDeepestActiveRoute`](https://github.com/max-scopp/reactive-kit/blob/main/packages/reactive-lib/routing/src/reactive/inject-deepest-active-route.ts)

TODO:
- [ ] Docs
- [ ] Tests