### PR TITLE
feat(inject-rate-limited): add rate-limited signal functionality

### DIFF
--- a/libs/ngxtension/inject-rate-limited/README.md
+++ b/libs/ngxtension/inject-rate-limited/README.md
@@ -1,0 +1,3 @@
+# ngxtension/inject-rate-limited
+
+Secondary entry point of `ngxtension`. It can be used by importing from `ngxtension/inject-rate-limited`.

--- a/libs/ngxtension/inject-rate-limited/ng-package.json
+++ b/libs/ngxtension/inject-rate-limited/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/ngxtension/inject-rate-limited/src/index.ts
+++ b/libs/ngxtension/inject-rate-limited/src/index.ts
@@ -1,0 +1,1 @@
+export * from './inject-rate-limited';

--- a/libs/ngxtension/inject-rate-limited/src/inject-rate-limited.ts
+++ b/libs/ngxtension/inject-rate-limited/src/inject-rate-limited.ts
@@ -1,0 +1,98 @@
+import {
+	inject,
+	InjectionToken,
+	Injector,
+	signal,
+	WritableSignal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { assertInjector } from 'ngxtension/assert-injector';
+import {
+	asyncScheduler,
+	auditTime,
+	debounceTime,
+	sampleTime,
+	Subject,
+	ThrottleConfig,
+	throttleTime,
+} from 'rxjs';
+
+const NGXTENSION_RATE_LIMIT = new InjectionToken('NGXTENSION_RATE_LIMIT', {
+	providedIn: 'root',
+	factory: () => 200,
+});
+
+export type RateLimitedSignal<T> = Pick<WritableSignal<T>, 'set' | 'update'>;
+
+export interface RateLimitedSignalOptions {
+	/**
+	 * Time window in milliseconds used by the operator.
+	 * Defaults to the NGXTENSION_RATE_LIMIT injection token.
+	 */
+	durationMs?: number;
+
+	/**
+	 * RxJS operator used to rate-limit updates.
+	 * @default debounceTime
+	 */
+	operator?:
+		| typeof debounceTime
+		| typeof throttleTime
+		| typeof sampleTime
+		| typeof auditTime;
+
+	/**
+	 * Optional injector override.
+	 */
+	injector?: Injector;
+
+	/**
+	 * Configuration for `throttleTime`, if used.
+	 * @default { leading: true, trailing: false }
+	 */
+	config?: ThrottleConfig;
+}
+
+/**
+ * Creates a signal that buffers and emits updates using a rate-limiting RxJS operator.
+ */
+export function injectRateLimited<T>(
+	initialValue: T,
+	options: RateLimitedSignalOptions = {},
+): RateLimitedSignal<T> {
+	return assertInjector(injectRateLimited, options?.injector, () => {
+		const defaultRateLimit = inject(NGXTENSION_RATE_LIMIT);
+
+		const {
+			durationMs: delayMs = defaultRateLimit,
+			operator = debounceTime,
+			config = {
+				leading: true,
+				trailing: false,
+			},
+		} = options;
+
+		const subject = new Subject<T>();
+		const inner = signal<T>(initialValue);
+
+		const stream = subject.pipe(operator(delayMs, asyncScheduler, config));
+
+		stream.pipe(takeUntilDestroyed()).subscribe((value) => inner.set(value));
+
+		return new Proxy(inner, {
+			get(target, prop, receiver) {
+				switch (prop) {
+					case 'set':
+						return (value: T) => subject.next(value);
+					case 'update':
+						return (updater: (value: T) => T) => {
+							const nextValue = updater(inner());
+							subject.next(nextValue);
+						};
+					default:
+						return Reflect.get(target, prop, receiver);
+				}
+			},
+		});
+	});
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -108,6 +108,9 @@
 			"ngxtension/inject-query-params": [
 				"libs/ngxtension/inject-query-params/src/index.ts"
 			],
+			"ngxtension/inject-rate-limited": [
+				"libs/ngxtension/inject-rate-limited/src/index.ts"
+			],
 			"ngxtension/inject-route-data": [
 				"libs/ngxtension/inject-route-data/src/index.ts"
 			],


### PR DESCRIPTION
Closes #595

@ptandler @dzolotarova

Introduces `injectRateLimited` 

Usages

```ts
const searchQuery = injectRateLimited(""); // debounced signal, 200ms

// throttled, at start, 100ms
const searchQuery = injectRateLimited("", {
    durationMs: 100,
    operator: throttleTime
});

// throttled, at end, 200ms
const searchQuery = injectRateLimited("", {
    operator: throttleTime,
    config: { // default config of leading: true is ignored
        trailing: true,
    }
});

// sampling every 200ms
const searchQuery = injectRateLimited("", {
    operator: sampleTime
});

// audit every 200ms
const searchQuery = injectRateLimited("", {
    operator: auditTime
});
```

```html
<!-- use in html template -->
<input type="search" (input)="searchQuery.set($any($event.target).value)" />
```