### PR TITLE
feat(inject-local-storage): promote NGXTENSION_LOCAL_STORAGE token to platform level

### DIFF
--- a/libs/ngxtension/inject-local-storage/src/inject-local-storage.spec.ts
+++ b/libs/ngxtension/inject-local-storage/src/inject-local-storage.spec.ts
@@ -293,7 +293,6 @@ describe('injectLocalStorage', () => {
 				const config = signal({ maxLength: 10 });
 				const value = injectLocalStorage<string[]>('test', {
 					stringify: (items) =>
-						// @ts-expect-error https://github.com/ngxtension/ngxtension-platform/pull/596
 						JSON.stringify(items.slice(0, config().maxLength)),
 					defaultValue: [],
 				});

--- a/libs/ngxtension/inject-local-storage/src/inject-local-storage.ts
+++ b/libs/ngxtension/inject-local-storage/src/inject-local-storage.ts
@@ -16,7 +16,7 @@ import { assertInjector } from 'ngxtension/assert-injector';
 export const NGXTENSION_LOCAL_STORAGE = new InjectionToken(
 	'NGXTENSION_LOCAL_STORAGE',
 	{
-		providedIn: 'root',
+		providedIn: 'platform',
 		factory: () => localStorage, // this would be the default
 	},
 );


### PR DESCRIPTION
Currently there is no possibility to use `injectLocalStorage` on platform level injection context, without specify explicit providers at the platform.

And there is no possibility to provide specified `NGXTENSION_LOCAL_STORAGE` at the platform level to every application instances on the page, because `NGXTENSION_LOCAL_STORAGE` has `providedIn: root`, and if we inject this token, it overrides `NGXTENSION_LOCAL_STORAGE` from the platform.

